### PR TITLE
Add option to disable internal datetime conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ It accepts options via an `option` keyword argument. These include:
 limit is otherwise 64 bits, the same as the Python standard library.
 - `orjson.OPT_NAIVE_UTC` for assuming `datetime.datetime` objects without a
 `tzinfo` are UTC.
+- `orjson.OPT_NO_RFC3339` to not encode `datetime.datetime` objects into
+RFC3339 strings.
 
 To specify multiple options, mask them together, e.g.,
 `option=orjson.OPT_STRICT_INTEGER | orjson.OPT_NAIVE_UTC`.
@@ -186,6 +188,9 @@ ISO 8601.
 `tzinfo`, if specified, must be a timezone object that is either
 `datetime.timezone.utc` or from the `pendulum`, `pytz`, or
 `dateutil`/`arrow` libraries.
+
+To disable the builtin serializer (and use your own default hook) use
+`orjson.OPT_NO_RFC3339`.
 
 ```python
 >>> import orjson, datetime, pendulum

--- a/orjson.pyi
+++ b/orjson.pyi
@@ -10,3 +10,4 @@ class JSONEncodeError(TypeError): ...
 
 OPT_STRICT_INTEGER: int
 OPT_NAIVE_UTC: int
+OPT_NO_RFC3339: int

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -16,8 +16,9 @@ const STRICT_INT_MAX: i64 = 9007199254740991;
 
 pub const STRICT_INTEGER: u8 = 1;
 pub const NAIVE_UTC: u8 = 1 << 1;
+pub const NO_RFC3339: u8 = 1 << 2;
 
-pub const MAX_OPT: i8 = STRICT_INTEGER as i8 | NAIVE_UTC as i8;
+pub const MAX_OPT: i8 = STRICT_INTEGER as i8 | NAIVE_UTC as i8 | NO_RFC3339 as i8;
 
 const HYPHEN: u8 = 45; // "-"
 const PLUS: u8 = 43; // "+"
@@ -165,7 +166,7 @@ impl<'p> Serialize for SerializePyObject {
                 } else {
                     serializer.serialize_seq(None).unwrap().end()
                 }
-            } else if unsafe { obj_ptr == DATETIME_PTR } {
+            } else if (self.opts & NO_RFC3339 != NO_RFC3339) && unsafe { obj_ptr == DATETIME_PTR } {
                 let has_tz =
                     unsafe { (*(self.ptr as *mut pyo3::ffi::PyDateTime_DateTime)).hastzinfo == 1 };
                 let offset_day: i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ fn orjson(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("JSONEncodeError", py.get_type::<exc::JSONEncodeError>())?;
     m.add("OPT_STRICT_INTEGER", encode::STRICT_INTEGER.into_object(py))?;
     m.add("OPT_NAIVE_UTC", encode::NAIVE_UTC.into_object(py))?;
+    m.add("OPT_NO_RFC3339", encode::NO_RFC3339.into_object(py))?;
 
     Ok(())
 }

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -90,7 +90,7 @@ class ApiTests(unittest.TestCase):
         dumps() option out of range high
         """
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=4)
+            orjson.dumps(True, option=orjson.OPT_NO_RFC3339 << 1)
 
     def test_opts_multiple(self):
         """

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -210,6 +210,20 @@ class DatetimeTests(unittest.TestCase):
             b'["1937-01-01T12:00:27.87+00:20"]',
         )
 
+    def test_datetime_no_rfc3339(self):
+        """
+        datetime.datetime not as RFC33339
+        """
+        def dflt(obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.isoformat()
+            return obj
+
+        self.assertEqual(
+            orjson.dumps([datetime.datetime(1937, 1, 1, 12, 0, 27, 87, tzinfo=tz.gettz('Europe/Amsterdam'))], default=dflt, option=orjson.OPT_NO_RFC3339),
+            b'["1937-01-01T12:00:27.000087+00:19:32"]',
+        )
+
 
 class DateTests(unittest.TestCase):
 


### PR DESCRIPTION
This adds a new option OPT_NO_RFC3339 to allow the user to implement a
custom datetime serialization via a default hook.