### PR TITLE
Feature: serialize UUIDs natively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pyo3 = { version = "0.9.0-alpha.1", default_features = false, features = ["exten
 rand = { version = "0.7", default_features = false, features = ["getrandom", "std"] }
 serde = { version = "1", default_features = false }
 serde_json = { git = "https://github.com/ijl/json.git", rev = "83efe507487afe2332c5d6f83d28056159a58e5d", default_features = false, features = ["perfect_float"] }
-smallvec = { version = "1", default_features = false, features = ["union", "specialization"] }
+smallvec = { version = "1", default_features = false, features = ["union", "specialization", "write"] }
 wyhash = { version = "0.3" }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ b'"1970-01-01T00:00:00+00:00"'
     )
 b'"1970-01-01T00:00:00Z"'
 ```
+##### OPT_SERIALIZE_UUID
+
+Serialize `uuid.UUID` instances. For more, see [uuid](#uuid).
 
 ### Deserialize
 
@@ -422,6 +425,19 @@ JSONDecodeError: unexpected end of hex escape at line 1 column 8: line 1 column 
 ValueError: Parse error at offset 1: The surrogate pair in string is invalid.
 >>> json.loads('"\\ud800"')
 '\ud800'
+```
+
+### uuid
+
+If the `OPT_SERIALIZE_UUID` option is provided, orjson serializes
+`uuid.UUID` objects natively in ["canonical"](https://en.wikipedia.org/wiki/Universally_unique_identifier#Format)
+format: as 32 hexadecimal digits, in 5 groups separated by hyphens,
+in the form 8-4-4-4-12, for a total of 36 characters.
+
+``` python
+>>> import orjson, uuid
+>>> orjson.dumps(uuid.UUID(int=0x12345678123456781234567812345678), option=orjson.OPT_SERIALIZE_UUID)
+b'"12345678-1234-5678-1234-567812345678"'
 ```
 
 ## Testing

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -7,7 +7,8 @@ use pyo3::prelude::*;
 use serde::ser::{self, Serialize, SerializeMap, SerializeSeq, Serializer};
 use smallvec::SmallVec;
 use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::io::Write;
+use std::os::raw::{c_char, c_uchar};
 use std::ptr::NonNull;
 
 // https://tools.ietf.org/html/rfc7159#section-6
@@ -19,6 +20,7 @@ const RECURSION_LIMIT: u8 = 255;
 
 pub const STRICT_INTEGER: u8 = 1;
 pub const SERIALIZE_DATACLASS: u8 = 1 << 4;
+pub const SERIALIZE_UUID: u8 = 1 << 5;
 
 macro_rules! obj_name {
     ($obj:ident) => {
@@ -186,6 +188,44 @@ impl<'p> Serialize for SerializePyObject {
             let mut dt: SmallVec<[u8; 32]> = SmallVec::with_capacity(32);
             write_time(self.ptr, self.opts, &mut dt);
             serializer.serialize_str(str_from_slice!(dt.as_ptr(), dt.len()))
+        } else if is_type!(obj_ptr, UUID_PTR) && (self.opts & SERIALIZE_UUID == SERIALIZE_UUID) {
+            // In Python, `self.int` is the 128-bit integer value of the UUID;
+            // we can assume this will not fail, as tested in `test_uuid.py`
+            let py_int = ffi!(PyObject_GetAttr(self.ptr, INT_ATTR_STR));
+            // Copied in from https://github.com/PyO3/pyo3/blob/fb17d5e82f302f09b6611ac608edd1ce37504703/src/types/num.rs#L95
+            // because we don't have a `pyo3::Python` reference. However, because
+            // we haven't yet Py_DECREF'd the `py_int` attribute, the reference
+            // to `self.int` should be valid, and this should be safe to do.
+            // We know it's a `PyLongObject` because `self.int` is a 128-bit int,
+            // and know that _PyLong_AsByteArray won't error, as tested in test_uuid.py
+            let buffer: [c_uchar; 16] = [0; 16];
+            unsafe {
+                pyo3::ffi::_PyLong_AsByteArray(
+                    py_int as *mut pyo3::ffi::PyLongObject,
+                    buffer.as_ptr() as *const c_uchar,
+                    16,
+                    1, // Return a little-endian array
+                    0, // Unsigned - UUIDs can't be negative
+                )
+            };
+            ffi!(Py_DECREF(py_int));
+            let value = u128::from_le_bytes(buffer);
+            let mut hexadecimal: SmallVec<[u8; 32]> = SmallVec::with_capacity(32);
+            write!(hexadecimal, "{:032x}", value).unwrap();
+            // Now we manually format it in canonical form: 5 groups separated
+            // by hyphens, 8-4-4-4-12
+            // https://en.wikipedia.org/wiki/Universally_unique_identifier#Format
+            let mut formatted: SmallVec<[u8; 36]> = SmallVec::with_capacity(36);
+            formatted.extend_from_slice(&hexadecimal[..8]);
+            formatted.push('-' as u8);
+            formatted.extend_from_slice(&hexadecimal[8..12]);
+            formatted.push('-' as u8);
+            formatted.extend_from_slice(&hexadecimal[12..16]);
+            formatted.push('-' as u8);
+            formatted.extend_from_slice(&hexadecimal[16..20]);
+            formatted.push('-' as u8);
+            formatted.extend_from_slice(&hexadecimal[20..]);
+            serializer.serialize_str(str_from_slice!(formatted.as_ptr(), 36))
         } else {
             if self.opts & SERIALIZE_DATACLASS == SERIALIZE_DATACLASS
                 && ffi!(PyObject_HasAttr(self.ptr, DATACLASS_FIELDS_STR)) == 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ const MAX_OPT: i8 = (encode::STRICT_INTEGER
     | datetime::NAIVE_UTC
     | datetime::OMIT_MICROSECONDS
     | datetime::UTC_Z
-    | encode::SERIALIZE_DATACLASS) as i8;
+    | encode::SERIALIZE_DATACLASS
+    | encode::SERIALIZE_UUID) as i8;
 
 #[pymodule]
 fn orjson(py: Python, m: &PyModule) -> PyResult<()> {
@@ -58,6 +59,7 @@ fn orjson(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("OPT_STRICT_INTEGER", encode::STRICT_INTEGER)?;
     m.add("OPT_UTC_Z", datetime::UTC_Z)?;
     m.add("OPT_SERIALIZE_DATACLASS", encode::SERIALIZE_DATACLASS)?;
+    m.add("OPT_SERIALIZE_UUID", encode::SERIALIZE_UUID)?;
 
     Ok(())
 }

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -89,7 +89,7 @@ class ApiTests(unittest.TestCase):
         dumps() option out of range high
         """
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=1 << 5)
+            orjson.dumps(True, option=1 << 6)
 
     def test_opts_multiple(self):
         """

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -7,6 +7,14 @@ import uuid
 import orjson
 
 
+class Custom:
+    def __init__(self):
+        self.name = uuid.uuid4().hex
+
+    def __str__(self):
+        return "%s(%s)" % (self.__class__.__name__, self.name)
+
+
 class Recursive:
     def __init__(self, cur):
         self.cur = cur
@@ -25,13 +33,13 @@ class TypeTests(unittest.TestCase):
         dumps() default not callable
         """
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(uuid.uuid4(), default=NotImplementedError)
+            orjson.dumps(Custom(), default=NotImplementedError)
 
     def test_default_func(self):
         """
         dumps() default function
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return str(obj)
@@ -44,7 +52,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default function None ok
         """
-        self.assertEqual(orjson.dumps(uuid.uuid4(), default=lambda x: None), b"null")
+        self.assertEqual(orjson.dumps(Custom(), default=lambda x: None), b"null")
 
     def test_default_func_exc(self):
         """
@@ -55,13 +63,13 @@ class TypeTests(unittest.TestCase):
             raise NotImplementedError
 
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(uuid.uuid4(), default=default)
+            orjson.dumps(Custom(), default=default)
 
     def test_default_func_nested_str(self):
         """
         dumps() default function nested str
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return str(obj)
@@ -75,10 +83,10 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default function nested list
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
-            if isinstance(obj, uuid.UUID):
+            if isinstance(obj, Custom):
                 return [str(obj)]
 
         self.assertEqual(
@@ -90,7 +98,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default function list
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return str(obj)
@@ -105,7 +113,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default function errors on non-str
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return bytes(obj)
@@ -117,7 +125,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default function errors on invalid str
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return "\ud800"
@@ -129,7 +137,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default lambda
         """
-        ref = uuid.uuid4()
+        ref = Custom()
         self.assertEqual(
             orjson.dumps(ref, default=lambda x: str(x)),
             b'"%s"' % str(ref).encode("utf-8"),
@@ -149,7 +157,7 @@ class TypeTests(unittest.TestCase):
                     self._cache[obj] = str(obj)
                 return self._cache[obj]
 
-        ref_obj = uuid.uuid4()
+        ref_obj = Custom()
         ref_bytes = b'"%s"' % str(ref_obj).encode("utf-8")
         for obj in [ref_obj] * 100:
             self.assertEqual(orjson.dumps(obj, default=CustomSerializer()), ref_bytes)
@@ -176,7 +184,7 @@ class TypeTests(unittest.TestCase):
         """
         dumps() default infinite recursion
         """
-        ref = uuid.uuid4()
+        ref = Custom()
 
         def default(obj):
             return obj

--- a/test/test_memory.py
+++ b/test/test_memory.py
@@ -5,7 +5,6 @@ import datetime
 import gc
 import random
 import unittest
-import uuid
 from typing import List
 
 import orjson
@@ -81,7 +80,15 @@ class MemoryTests(unittest.TestCase):
         proc = psutil.Process()
         gc.collect()
         fixture = orjson.loads(FIXTURE)
-        fixture["custom"] = uuid.uuid4()
+
+        class Custom:
+            def __init__(self, name):
+                self.name = name
+
+            def __str__(self):
+                return "%s(%s)" % (self.__class__.__name__, self.name)
+
+        fixture["custom"] = Custom("orjson")
         val = orjson.dumps(fixture, default=default)
         mem = proc.memory_info().rss
         for _ in range(10000):

--- a/test/test_uuid.py
+++ b/test/test_uuid.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 import uuid
 import unittest
+
+import orjson
 
 
 class UUIDTests(unittest.TestCase):
@@ -33,3 +36,57 @@ class UUIDTests(unittest.TestCase):
             uuid.UUID(int=2 ** 128)
         with self.assertRaises(ValueError):
             uuid.UUID(int=-1)
+
+    def test_all_ways_to_create_uuid_behave_equivalently(self):
+        # Note that according to the docstring for the uuid.UUID class, all the
+        # forms below are equivalent -- they end up with the same value for
+        # `self.int`, which is all that really matters
+        uuids = [
+            uuid.UUID("{12345678-1234-5678-1234-567812345678}"),
+            uuid.UUID("12345678123456781234567812345678"),
+            uuid.UUID("urn:uuid:12345678-1234-5678-1234-567812345678"),
+            uuid.UUID(bytes=b"\x12\x34\x56\x78" * 4),
+            uuid.UUID(
+                bytes_le=b"\x78\x56\x34\x12\x34\x12\x78\x56"
+                + b"\x12\x34\x56\x78\x12\x34\x56\x78"
+            ),
+            uuid.UUID(fields=(0x12345678, 0x1234, 0x5678, 0x12, 0x34, 0x567812345678)),
+            uuid.UUID(int=0x12345678123456781234567812345678),
+        ]
+        result = orjson.dumps(uuids, option=orjson.OPT_SERIALIZE_UUID)
+        canonical_uuids = ['"%s"' % str(u) for u in uuids]
+        serialized = ("[%s]" % ",".join(canonical_uuids)).encode("utf8")
+        self.assertEqual(result, serialized)
+
+    def test_serialize_natively_equivalent_to_str(self):
+        uuid_ = uuid.uuid4()
+        self.assertEqual(
+            orjson.dumps([uuid_], option=orjson.OPT_SERIALIZE_UUID),
+            orjson.dumps([uuid_], default=str),
+        )
+
+    def test_does_not_serialize_without_opt(self):
+        with self.assertRaises(orjson.JSONEncodeError):
+            _ = orjson.dumps([uuid.uuid4()])
+
+    def test_serializes_correctly_with_leading_zeroes(self):
+        instance = uuid.UUID(int=0x00345678123456781234567812345678)
+        self.assertEqual(
+            orjson.dumps(instance, option=orjson.OPT_SERIALIZE_UUID),
+            ('"%s"' % str(instance)).encode("utf8"),
+        )
+
+    def test_all_uuid_creation_functions_create_serializable_uuids(self):
+        all_versioned_uuids = [
+            uuid.uuid1(),
+            uuid.uuid3(uuid.NAMESPACE_DNS, "python.org"),
+            uuid.uuid4(),
+            uuid.uuid5(uuid.NAMESPACE_DNS, "python.org"),
+        ]
+        serialized = orjson.dumps(all_versioned_uuids, option=orjson.OPT_SERIALIZE_UUID)
+        # Ensure that all the creator functions produce UUID strings that match
+        # our expected 8-4-4-4-12 hexadecimal format
+        assert re.match(
+            rb'\[("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",?){4}]',
+            serialized,
+        )


### PR DESCRIPTION
Closes #41 

This is an initial, clumsy, incorrect implementation -- I'm not even sure how to run the tests at this point, and I know that converting the 128-bit `self.int` value in the `UUID` can't be as easy as calling one C function.

But I'd really appreciate some :eyes: and review while I figure out the rest (tips on what to do also appreciated ;-))