### PR TITLE
Enable compliant manylinux1 builds on Azure

### DIFF
--- a/ci/azure-linux-container.yml
+++ b/ci/azure-linux-container.yml
@@ -3,25 +3,29 @@ parameters:
   manylinux: ''
   path: ''
   target: ''
+  verifyManylinux: true
 
 steps:
 - bash: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly --profile minimal -y
   displayName: rustup
 - bash: PATH=$(path) rustup default nightly
   displayName: ensure nightly
-- bash: PATH=$(path) pip install --user --upgrade pip wheel maturin twine
+- bash: PATH=$(path) $(interpreter) -m pip install --user --upgrade pip wheel maturin twine
   displayName: build dependencies
-- bash: PATH=$(path) pip install --user -r test/requirements.txt -r integration/requirements.txt
+- bash: PATH=$(path) $(interpreter) -m pip install --user -r test/requirements.txt -r integration/requirements.txt
   displayName: test dependencies
 - bash: PATH=$(path) RUSTFLAGS="-Zmutable-noalias -C target-feature=+sse2" maturin build --release --strip --manylinux $(manylinux) --interpreter $(interpreter) --target $(target)
   displayName: build
-- bash: PATH=$(path) pip install --user target/wheels/orjson*.whl
+- bash: PATH=$(path) $(interpreter) -m pip install --user --upgrade auditwheel && PATH=$(path) $(interpreter) -m auditwheel repair target/wheels/orjson*.whl
+  displayName: verify that wheel conforms to manylinux tag
+  condition: eq('${{ parameters.verifyManylinux }}', true)
+- bash: PATH=$(path) $(interpreter) -m pip install --user target/wheels/orjson*.whl
   displayName: install
 - bash: PATH=$(path) pytest -s -rxX -v test
   displayName: pytest
-- bash: pip uninstall -y numpy
+- bash: PATH=$(path) $(interpreter) -m pip uninstall -y numpy
   displayName: remove optional packages
-- bash: pytest -s -rxX -v test
+- bash: PATH=$(path) pytest -s -rxX -v test
   displayName: pytest without optional packages
 - bash: PATH=$(path) ./integration/run thread
   displayName: thread

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -21,8 +21,9 @@ jobs:
   variables:
     interpreter: python3.9
     manylinux: 1
-    path: /home/vsts_azpcontainer/.local/bin:/home/vsts_azpcontainer/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    path: $HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     target: x86_64-unknown-linux-gnu
+    verifyManylinux: false
   steps:
   - checkout: self
   - template: ./azure-linux-container.yml
@@ -30,11 +31,11 @@ jobs:
 - job: linux_python38
   pool:
     vmImage: ubuntu-18.04
-  container: python:3.8-buster
+  container: quay.io/pypa/manylinux1_x86_64
   variables:
     interpreter: python3.8
     manylinux: 1
-    path: /home/vsts_azpcontainer/.local/bin:/home/vsts_azpcontainer/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    path: $HOME/.local/bin:$HOME/.cargo/bin:/opt/python/cp38-cp38/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     target: x86_64-unknown-linux-gnu
   steps:
   - checkout: self
@@ -43,11 +44,11 @@ jobs:
 - job: linux_python37
   pool:
     vmImage: ubuntu-18.04
-  container: python:3.7-buster
+  container: quay.io/pypa/manylinux1_x86_64
   variables:
     interpreter: python3.7
     manylinux: 1
-    path: /home/vsts_azpcontainer/.local/bin:/home/vsts_azpcontainer/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    path: $HOME/.local/bin:$HOME/.cargo/bin:/opt/python/cp37-cp37m/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     target: x86_64-unknown-linux-gnu
   steps:
   - checkout: self
@@ -56,11 +57,11 @@ jobs:
 - job: linux_python36
   pool:
     vmImage: ubuntu-18.04
-  container: python:3.6-buster
+  container: quay.io/pypa/manylinux1_x86_64
   variables:
     interpreter: python3.6
     manylinux: 1
-    path: /home/vsts_azpcontainer/.local/bin:/home/vsts_azpcontainer/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    path: $HOME/.local/bin:$HOME/.cargo/bin:/opt/python/cp36-cp36m/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     target: x86_64-unknown-linux-gnu
   steps:
   - checkout: self


### PR DESCRIPTION
This PR (hopefully) enables manylinux1 builds by using the [konstin2/maturin:master][konstin2-maturin] Docker image as outlined in https://github.com/ijl/orjson/issues/2#issuecomment-589150572.

I've completely removed Python 3.9 for now, as it is not yet included in the manylinux Docker image. The simplest solution would be to fallback to the previous template for Python 3.9.

[konstin2-maturin]: https://hub.docker.com/r/konstin2/maturin