### PR TITLE
Fix arithmetic overflow in HASH_SEED computation

### DIFF
--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -81,7 +81,7 @@ pub fn init_typerefs() {
         ARRAY_STRUCT_STR =
             pyo3::ffi::PyUnicode_InternFromString("__array_struct__\0".as_ptr() as *const c_char);
         VALUE_STR = pyo3::ffi::PyUnicode_InternFromString("value\0".as_ptr() as *const c_char);
-        HASH_SEED = VALUE_STR as u64 * DICT_TYPE as u64;
+        HASH_SEED = (VALUE_STR as u64).wrapping_mul(DICT_TYPE as u64);
     });
 }
 


### PR DESCRIPTION
This multiplication causes crashes if orjson is compiled in debug mode or with overflow-checks=true. Introduced in https://github.com/ijl/orjson/commit/bdb071420262e7fdfc2ca1fa8e5d85e4cd65c17d.

```console
thread '<unnamed>' panicked at 'attempt to multiply with overflow', orjson-2.6.6/src/typeref.rs:84:21
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at src/vendor/backtrace/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at src/vendor/backtrace/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1063
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1426
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:204
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:224
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:470
  11: rust_begin_unwind
             at src/libstd/panicking.rs:378
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  13: core::panicking::panic
             at src/libcore/panicking.rs:52
  14: orjson::typeref::init_typerefs::{closure#0}
             at orjson-2.6.6/src/typeref.rs:84
  15: std::sync::once::Once::call_inner
             at src/libstd/sync/once.rs:416
  16: <std::sync::once::Once>::call_once::<orjson::typeref::init_typerefs::{closure#0}>
             at src/libstd/sync/once.rs:264
  17: orjson::orjson
             at orjson-2.6.6/src/lib.rs:34
  18: <orjson::orjson as core::ops::function::Fn<(pyo3::python::Python, &pyo3::types::module::PyModule)>>::call
             at src/libcore/ops/function.rs:72
  19: <pyo3::derive_utils::ModuleDef>::make_module::<orjson::orjson>
             at pyo3-0.9.2/src/derive_utils.rs:157
  20: PyInit_orjson
             at orjson-2.6.6/src/lib.rs:32
  21: _PyImport_LoadDynamicModuleWithSpec
  22: _imp_create_dynamic
  23: _PyMethodDef_RawFastCallDict
  24: _PyCFunction_FastCallDict
  25: _PyEval_EvalFrameDefault
  26: _PyEval_EvalCodeWithName
  27: _PyFunction_FastCallKeywords
  28: _PyEval_EvalFrameDefault
  29: _PyFunction_FastCallKeywords
  30: _PyEval_EvalFrameDefault
  31: _PyFunction_FastCallKeywords
  32: _PyEval_EvalFrameDefault
  33: _PyFunction_FastCallKeywords
  34: _PyEval_EvalFrameDefault
  35: _PyFunction_FastCallKeywords
  36: _PyEval_EvalFrameDefault
  37: _PyFunction_FastCallDict
  38: object_vacall
  39: _PyObject_CallMethodIdObjArgs
  40: PyImport_ImportModuleLevelObject
  41: _PyEval_EvalFrameDefault
  42: _PyEval_EvalCodeWithName
  43: PyEval_EvalCodeEx
  44: PyEval_EvalCode
  45: builtin_exec
  46: _PyMethodDef_RawFastCallKeywords
  47: _PyCFunction_FastCallKeywords
  48: _PyEval_EvalFrameDefault
  49: _PyEval_EvalCodeWithName
  50: _PyFunction_FastCallKeywords
  51: _PyEval_EvalFrameDefault
  52: _PyEval_EvalCodeWithName
  53: _PyFunction_FastCallKeywords
  54: _PyEval_EvalFrameDefault
  55: _PyEval_EvalCodeWithName
  56: _PyFunction_FastCallKeywords
  57: _PyEval_EvalFrameDefault
  58: _PyEval_EvalCodeWithName
  59: PyEval_EvalCodeEx
  60: PyEval_EvalCode
  61: run_mod
  62: PyRun_StringFlags
  63: PyRun_SimpleStringFlags
  64: pymain_main
  65: _Py_UnixMain
  66: __libc_start_main
             at ../csu/libc-start.c:308
  67: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
```