### PR TITLE
fix: read_utf8_from_str ascii=1 but not compact case

### DIFF
--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -31,13 +31,19 @@ pub struct PyCompactUnicodeObject {
 
 const STATE_ASCII: u32 = 0b00000000000000000000000001000000;
 const STATE_COMPACT: u32 = 0b00000000000000000000000000100000;
+const STATE_COMPACT_ASCII: u32 = 0b00000000000000000000000001100000;
 
 #[inline]
 pub fn read_utf8_from_str(op: *mut PyObject, str_size: &mut Py_ssize_t) -> *const u8 {
     unsafe {
-        if likely!((*op.cast::<PyASCIIObject>()).state & STATE_ASCII == STATE_ASCII) {
+        if likely!((*op.cast::<PyASCIIObject>()).state & STATE_COMPACT_ASCII == STATE_COMPACT_ASCII) {
             *str_size = (*op.cast::<PyASCIIObject>()).length;
             op.cast::<PyASCIIObject>().offset(1) as *const u8
+        } else if likely!((*op.cast::<PyASCIIObject>()).state & STATE_ASCII == STATE_ASCII)
+            && !(*op.cast::<PyCompactUnicodeObject>()).utf8.is_null()
+        {
+            *str_size = (*op.cast::<PyCompactUnicodeObject>()).utf8_length;
+            (*op.cast::<PyCompactUnicodeObject>()).utf8 as *const u8
         } else if likely!((*op.cast::<PyASCIIObject>()).state & STATE_COMPACT == STATE_COMPACT)
             && !(*op.cast::<PyCompactUnicodeObject>()).utf8.is_null()
         {


### PR DESCRIPTION
fix `read_utf8_from_str` function for the case when ascii is set to 1 but compact not set.
according to https://github.com/python/cpython/blob/master/Include/cpython/unicodeobject.h#L205
PyASCIIObject structure is used only when ascii is set and compact is set.

Fixes #101 