### PR TITLE
orjson.dumps: fix inspect.signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::borrow::Cow;
 use std::os::raw::c_char;
 use std::ptr::NonNull;
 
-const DUMPS_DOC: &str = "dumps(obj, /, default, option)\n--\n\nSerialize Python objects to JSON.\0";
+const DUMPS_DOC: &str = "dumps(obj, /, default=None, option=None)\n--\n\nSerialize Python objects to JSON.\0";
 const LOADS_DOC: &str = "loads(obj, /)\n--\n\nDeserialize JSON to Python objects.\0";
 
 macro_rules! opt {

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -166,14 +166,17 @@ class ApiTests(unittest.TestCase):
         dumps() valid __text_signature__
         """
         self.assertEqual(
-            str(inspect.signature(orjson.dumps)), "(obj, /, default, option)"
+            str(inspect.signature(orjson.dumps)), "(obj, /, default=None, option=None)"
         )
+        inspect.signature(orjson.dumps).bind("str")
+        inspect.signature(orjson.dumps).bind("str", default=default, option=1)
 
     def test_loads_signature(self):
         """
         loads() valid __text_signature__
         """
         self.assertEqual(str(inspect.signature(orjson.loads)), "(obj, /)")
+        inspect.signature(orjson.loads).bind("[]")
 
     def test_bytes_buffer(self):
         """


### PR DESCRIPTION
For instance, you'd expect the following to work:

```
>>> inspect.signature(orjson.dumps).bind(["some json"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/shantanu/.pyenv/versions/3.7.7/lib/python3.7/inspect.py", line 3015, in bind
    return args[0]._bind(args[1:], kwargs)
  File "/Users/shantanu/.pyenv/versions/3.7.7/lib/python3.7/inspect.py", line 2930, in _bind
    raise TypeError(msg) from None
TypeError: missing a required argument: 'default'
```