### PR TITLE
Fixed bug on empty multidimensional numpy array

### DIFF
--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -242,54 +242,58 @@ impl<'p> Serialize for NumpyArray {
         S: Serializer,
     {
         let mut seq = serializer.serialize_seq(None).unwrap();
-        if !self.children.is_empty() {
-            for child in &self.children {
-                seq.serialize_element(child).unwrap();
-            }
-        } else {
-            let data_ptr = self.data();
-            let num_items = self.num_items();
-            match self.kind().unwrap() {
-                ItemType::F64 => {
-                    let slice: &[f64] = slice!(data_ptr as *const f64, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeF64 { obj: each }).unwrap();
-                    }
+
+        if self.depth >= self.shape().len() || self.shape()[self.depth] != 0 {
+            if !self.children.is_empty() {
+                for child in &self.children {
+                    seq.serialize_element(child).unwrap();
                 }
-                ItemType::F32 => {
-                    let slice: &[f32] = slice!(data_ptr as *const f32, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeF32 { obj: each }).unwrap();
+
+            } else {
+                let data_ptr = self.data();
+                let num_items = self.num_items();
+                match self.kind().unwrap() {
+                    ItemType::F64 => {
+                        let slice: &[f64] = slice!(data_ptr as *const f64, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeF64 { obj: each }).unwrap();
+                        }
                     }
-                }
-                ItemType::I64 => {
-                    let slice: &[i64] = slice!(data_ptr as *const i64, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeI64 { obj: each }).unwrap();
+                    ItemType::F32 => {
+                        let slice: &[f32] = slice!(data_ptr as *const f32, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeF32 { obj: each }).unwrap();
+                        }
                     }
-                }
-                ItemType::I32 => {
-                    let slice: &[i32] = slice!(data_ptr as *const i32, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeI32 { obj: each }).unwrap();
+                    ItemType::I64 => {
+                        let slice: &[i64] = slice!(data_ptr as *const i64, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeI64 { obj: each }).unwrap();
+                        }
                     }
-                }
-                ItemType::U64 => {
-                    let slice: &[u64] = slice!(data_ptr as *const u64, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeU64 { obj: each }).unwrap();
+                    ItemType::I32 => {
+                        let slice: &[i32] = slice!(data_ptr as *const i32, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeI32 { obj: each }).unwrap();
+                        }
                     }
-                }
-                ItemType::U32 => {
-                    let slice: &[u32] = slice!(data_ptr as *const u32, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeU32 { obj: each }).unwrap();
+                    ItemType::U64 => {
+                        let slice: &[u64] = slice!(data_ptr as *const u64, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeU64 { obj: each }).unwrap();
+                        }
                     }
-                }
-                ItemType::BOOL => {
-                    let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
-                    for &each in slice.iter() {
-                        seq.serialize_element(&DataTypeBOOL { obj: each }).unwrap();
+                    ItemType::U32 => {
+                        let slice: &[u32] = slice!(data_ptr as *const u32, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeU32 { obj: each }).unwrap();
+                        }
+                    }
+                    ItemType::BOOL => {
+                        let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
+                        for &each in slice.iter() {
+                            seq.serialize_element(&DataTypeBOOL { obj: each }).unwrap();
+                        }
                     }
                 }
             }

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -210,6 +210,24 @@ class NumpyTests(unittest.TestCase):
         with self.assertRaises(orjson.JSONEncodeError):
             orjson.dumps(array, option=orjson.OPT_SERIALIZE_NUMPY)
 
+        array = numpy.empty(( 0, 4, 2 ))
+        self.assertEqual(
+            orjson.loads(orjson.dumps(array, option=orjson.OPT_SERIALIZE_NUMPY,)),
+            array.tolist(),
+        )
+
+        array = numpy.empty(( 4, 0, 2 ))
+        self.assertEqual(
+            orjson.loads(orjson.dumps(array, option=orjson.OPT_SERIALIZE_NUMPY,)),
+            array.tolist(),
+        )
+
+        array = numpy.empty(( 2, 4, 0 ))
+        self.assertEqual(
+            orjson.loads(orjson.dumps(array, option=orjson.OPT_SERIALIZE_NUMPY,)),
+            array.tolist(),
+        )
+
     def test_numpy_array_dimension_max(self):
         array = numpy.random.rand(
             1,


### PR DESCRIPTION
I found out that when serializing multidimensional empty numpy arrays (on version 3.3.1) was returning some uninitialized values as below:

```py
>>> import orjson
>>> import numpy as np
>>> arr = np.empty(( 0, 4, 2 ), np.float32) # an empty array of 4x2 arrays
>>> orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
b'[-4.9498488e33,4.5716e-41]'
>>> arr = np.empty(( 4, 0, 2 ), np.float32) # a 4-dimensional array of empty arrays
>>> orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
b'[[0.049861312,3.068e-41],[0.0,0.0],[3e-45,0.0],[null,null]]'
```

I simply added a check to handle those cases, now it works as expected:

```py
>>> import orjson
>>> import numpy as np
>>> arr = np.empty(( 0, 4, 2 ), np.float32) # an empty array of 4x2 arrays
>>> orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
b'[]'
>>> arr = np.empty(( 4, 0, 2 ), np.float32) # a 4-dimensional array of empty arrays
>>> orjson.dumps(arr, option=orjson.OPT_SERIALIZE_NUMPY)
b'[[],[],[],[]]'
```