### PR TITLE
transform PyModule_GetDict to gc-friendly PyObject_GenericGetDict

### DIFF
--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -112,7 +112,7 @@ pub fn init_typerefs() {
 
 unsafe fn look_up_json_exc() -> *mut PyObject {
     let module = PyImport_ImportModule("json\0".as_ptr() as *const c_char);
-    let module_dict = PyModule_GetDict(module);
+    let module_dict = PyObject_GenericGetDict(module, std::ptr::null_mut());
     let ptr = PyMapping_GetItemString(module_dict, "JSONDecodeError\0".as_ptr() as *const c_char)
         as *mut PyObject;
     let res = pyo3::ffi::PyErr_NewException(
@@ -130,7 +130,7 @@ unsafe fn look_up_numpy_type(
     numpy_module: *mut PyObject,
     np_type: &str,
 ) -> Option<NonNull<PyTypeObject>> {
-    let mod_dict = PyModule_GetDict(numpy_module);
+    let mod_dict = PyObject_GenericGetDict(numpy_module, std::ptr::null_mut());
     let ptr = PyMapping_GetItemString(mod_dict, np_type.as_ptr() as *const c_char);
     Py_XDECREF(ptr);
     // Py_XDECREF(mod_dict) causes segfault when pytest exits
@@ -161,7 +161,7 @@ unsafe fn load_numpy_types() -> Option<NumpyTypes> {
 
 unsafe fn look_up_field_type() -> NonNull<PyObject> {
     let module = PyImport_ImportModule("dataclasses\0".as_ptr() as *const c_char);
-    let module_dict = PyModule_GetDict(module);
+    let module_dict = PyObject_GenericGetDict(module, std::ptr::null_mut());
     let ptr = PyMapping_GetItemString(module_dict, "_FIELD\0".as_ptr() as *const c_char)
         as *mut PyTypeObject;
     Py_DECREF(module_dict);
@@ -171,7 +171,7 @@ unsafe fn look_up_field_type() -> NonNull<PyObject> {
 
 unsafe fn look_up_enum_type() -> *mut PyTypeObject {
     let module = PyImport_ImportModule("enum\0".as_ptr() as *const c_char);
-    let module_dict = PyModule_GetDict(module);
+    let module_dict = PyObject_GenericGetDict(module, std::ptr::null_mut());
     let ptr = PyMapping_GetItemString(module_dict, "EnumMeta\0".as_ptr() as *const c_char)
         as *mut PyTypeObject;
     Py_DECREF(module_dict);
@@ -181,7 +181,7 @@ unsafe fn look_up_enum_type() -> *mut PyTypeObject {
 
 unsafe fn look_up_uuid_type() -> *mut PyTypeObject {
     let uuid_mod = PyImport_ImportModule("uuid\0".as_ptr() as *const c_char);
-    let uuid_mod_dict = PyModule_GetDict(uuid_mod);
+    let uuid_mod_dict = PyObject_GenericGetDict(uuid_mod, std::ptr::null_mut());
     let uuid = PyMapping_GetItemString(uuid_mod_dict, "NAMESPACE_DNS\0".as_ptr() as *const c_char);
     let ptr = (*uuid).ob_type;
     Py_DECREF(uuid);


### PR DESCRIPTION
Fix "the refcount is too small issue" https://github.com/ijl/orjson/issues/144
Found that the json/enum/uuid type init func lead this issue. It is absent of the incref for the funcobject.globals, but once gc is enabled or when app finished with gc disabled, the cpython func_clear will decref the globals.  Then once gc collect run (whether or not gc enabled,when running app or exit app ), will find this error. Becasue PyModule_GetDict  did not incref ,but func_clear decref. 

Now also add another fix : field and numpy typeinit func .