### PR TITLE
Transform the PyObject instance struct gc friendly,

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -20,15 +20,6 @@ pub struct LocalPyTypeObject {
     // ...
 }
 
-#[repr(C)]
-pub struct PyDictObject {
-    pub ob_refcnt: Py_ssize_t,
-    pub ob_type: *mut PyTypeObject,
-    pub ma_used: Py_ssize_t,
-    pub ma_version_tag: u64,
-    pub ma_keys: *mut pyo3::ffi::PyObject,
-    pub ma_values: *mut *mut pyo3::ffi::PyObject,
-}
 
 #[allow(non_snake_case)]
 #[inline(always)]
@@ -38,9 +29,7 @@ pub unsafe fn PyDict_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
 
 #[repr(C)]
 pub struct PyBytesObject {
-    pub ob_refcnt: Py_ssize_t,
-    pub ob_type: *mut PyTypeObject,
-    pub ob_size: Py_ssize_t,
+    pub ob_base: PyVarObject,
     pub ob_shash: Py_hash_t,
     pub ob_sval: [c_char; 1],
 }
@@ -54,5 +43,5 @@ pub unsafe fn PyBytes_AS_STRING(op: *mut PyObject) -> *const c_char {
 #[allow(non_snake_case)]
 #[inline(always)]
 pub unsafe fn PyBytes_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
-    (*op.cast::<PyBytesObject>()).ob_size
+    (*op.cast::<PyVarObject>()).ob_size    
 }

--- a/src/serialize/writer.rs
+++ b/src/serialize/writer.rs
@@ -25,7 +25,7 @@ impl BytesWriter {
     #[inline]
     pub fn finish(&mut self) -> NonNull<PyObject> {
         unsafe {
-            (*self.bytes).ob_size = self.len as isize;
+            (*self.bytes.cast::<PyVarObject>()).ob_size = self.len as Py_ssize_t;
             self.resize(self.len as isize);
             NonNull::new_unchecked(self.bytes as *mut PyObject)
         }


### PR DESCRIPTION
Fix some issues the hardcoded struct lead for dumps and loads when using the debug python.  Such as
1.  dump()
refcnt issue:bad argument to internal function when dumps(dict). If just fix the ref issue, also lead the  dict size incorrect issue etc.
https://github.com/ijl/orjson/issues/144

2.   loads()
orjson.loads(b'"\xed\xa0\x80"'.decode("utf-8", "replace") show nothing
some crash in the unicodetype process when load()

All issues is related with the non-gc friendly rust python object struct design issue.

Among the fix, also use PyDictObject from pyo3::ffi, not ours hardcoded struct.