### PR TITLE
support np.int16, np.uint16 and np.float16

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,11 +788,12 @@ JSONEncodeError: Integer exceeds 53-bit range
 ### numpy
 
 orjson natively serializes `numpy.ndarray` and individual `numpy.float64`,
-`numpy.float32`, `numpy.int64`, `numpy.int32`, `numpy.int8`, `numpy.uint64`,
-`numpy.uint32`, and `numpy.uint8` instances. Arrays may have a
-`dtype` of `numpy.bool`, `numpy.float32`, `numpy.float64`, `numpy.int32`,
-`numpy.int64`, `numpy.uint32`, `numpy.uint64`, `numpy.uintp`, or `numpy.intp`.
-orjson is faster than all compared libraries at serializing
+`numpy.float32`, `numpy.float16`, `numpy.int64`, `numpy.int32`, `numpy.int16`,
+`numpy.int8`, `numpy.uint64`, `numpy.uint32`, `numpy.uint16` and `numpy.uint8`
+instances. Arrays may have a `dtype` of `numpy.bool`, `numpy.float16`, `numpy.float32`,
+`numpy.float64`, `numpy.int8`, `numpy.int16`, `numpy.int32`, `numpy.int64`,
+`numpy.uint8`, `numpy.uint16`, `numpy.uint32`, `numpy.uint64`, `numpy.uintp`
+or `numpy.intp`. orjson is faster than all compared libraries at serializing
 numpy instances. Serializing numpy data requires specifying
 `option=orjson.OPT_SERIALIZE_NUMPY`.
 

--- a/pynumpy
+++ b/pynumpy
@@ -23,19 +23,25 @@ os.sched_setaffinity(os.getpid(), {0, 1})
 
 kind = sys.argv[1] if len(sys.argv) >= 1 else ""
 
-if kind == "int32":
-    array = numpy.random.randint(((2 ** 31) - 1), size=(100000, 100), dtype=numpy.int32)
+if kind == "bool":
+    array = numpy.random.choice((True, False), size=(100000, 200))
+elif kind == "float16":
+    array = numpy.random.random(size=(50000, 100), dtype=numpy.float16)
 elif kind == "float64":
     array = numpy.random.random(size=(50000, 100))
     assert array.dtype == numpy.float64
-elif kind == "bool":
-    array = numpy.random.choice((True, False), size=(100000, 200))
 elif kind == "int8":
     array = numpy.random.randint(((2 ** 7) - 1), size=(100000, 100), dtype=numpy.int8)
+elif kind == "int16":
+    array = numpy.random.randint(((2 ** 15) - 1), size=(100000, 100), dtype=numpy.int16)
+elif kind == "int32":
+    array = numpy.random.randint(((2 ** 31) - 1), size=(100000, 100), dtype=numpy.int32)
 elif kind == "uint8":
     array = numpy.random.randint(((2 ** 8) - 1), size=(100000, 100), dtype=numpy.uint8)
+elif kind == "uint16":
+    array = numpy.random.randint(((2 ** 16) - 1), size=(100000, 100), dtype=numpy.uint16)
 else:
-    print("usage: pynumpy (bool|int32|float64|int8|uint8)")
+    print("usage: pynumpy (bool|float16|float64|int8|int16|int32|uint8|uint16)")
     sys.exit(1)
 proc = psutil.Process()
 

--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -17,11 +17,14 @@ pub fn is_numpy_scalar(ob_type: *mut PyTypeObject) -> bool {
         let scalar_types = unsafe { NUMPY_TYPES.as_ref().unwrap() };
         ob_type == scalar_types.float64
             || ob_type == scalar_types.float32
+            || ob_type == scalar_types.float16
             || ob_type == scalar_types.int64
             || ob_type == scalar_types.int32
+            || ob_type == scalar_types.int16
             || ob_type == scalar_types.int8
             || ob_type == scalar_types.uint64
             || ob_type == scalar_types.uint32
+            || ob_type == scalar_types.uint16
             || ob_type == scalar_types.uint8
             || ob_type == scalar_types.bool_
     }
@@ -439,16 +442,22 @@ impl<'p> Serialize for NumpyScalar {
                 (*(self.ptr as *mut NumpyFloat64)).serialize(serializer)
             } else if ob_type == scalar_types.float32 {
                 (*(self.ptr as *mut NumpyFloat32)).serialize(serializer)
+            } else if ob_type == scalar_types.float16 {
+                (*(self.ptr as *mut NumpyFloat16)).serialize(serializer)
             } else if ob_type == scalar_types.int64 {
                 (*(self.ptr as *mut NumpyInt64)).serialize(serializer)
             } else if ob_type == scalar_types.int32 {
                 (*(self.ptr as *mut NumpyInt32)).serialize(serializer)
+            } else if ob_type == scalar_types.int16 {
+                (*(self.ptr as *mut NumpyInt16)).serialize(serializer)
             } else if ob_type == scalar_types.int8 {
                 (*(self.ptr as *mut NumpyInt8)).serialize(serializer)
             } else if ob_type == scalar_types.uint64 {
                 (*(self.ptr as *mut NumpyUint64)).serialize(serializer)
             } else if ob_type == scalar_types.uint32 {
                 (*(self.ptr as *mut NumpyUint32)).serialize(serializer)
+            } else if ob_type == scalar_types.uint16 {
+                (*(self.ptr as *mut NumpyUint16)).serialize(serializer)
             } else if ob_type == scalar_types.uint8 {
                 (*(self.ptr as *mut NumpyUint8)).serialize(serializer)
             } else if ob_type == scalar_types.bool_ {
@@ -473,6 +482,22 @@ impl<'p> Serialize for NumpyInt8 {
         S: Serializer,
     {
         serializer.serialize_i8(self.value)
+    }
+}
+
+#[repr(C)]
+pub struct NumpyInt16 {
+    pub ob_refcnt: Py_ssize_t,
+    pub ob_type: *mut PyTypeObject,
+    pub value: i16,
+}
+
+impl<'p> Serialize for NumpyInt16 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_i16(self.value)
     }
 }
 
@@ -525,6 +550,22 @@ impl<'p> Serialize for NumpyUint8 {
 }
 
 #[repr(C)]
+pub struct NumpyUint16 {
+    pub ob_refcnt: Py_ssize_t,
+    pub ob_type: *mut PyTypeObject,
+    pub value: u16,
+}
+
+impl<'p> Serialize for NumpyUint16 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u16(self.value)
+    }
+}
+
+#[repr(C)]
 pub struct NumpyUint32 {
     pub ob_refcnt: Py_ssize_t,
     pub ob_type: *mut PyTypeObject,
@@ -553,6 +594,22 @@ impl<'p> Serialize for NumpyUint64 {
         S: Serializer,
     {
         serializer.serialize_u64(self.value)
+    }
+}
+
+#[repr(C)]
+pub struct NumpyFloat16 {
+    pub ob_refcnt: Py_ssize_t,
+    pub ob_type: *mut PyTypeObject,
+    pub value: f16,
+}
+
+impl<'p> Serialize for NumpyFloat16 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_f16(self.value)
     }
 }
 

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -11,11 +11,14 @@ pub struct NumpyTypes {
     pub array: *mut PyTypeObject,
     pub float64: *mut PyTypeObject,
     pub float32: *mut PyTypeObject,
+    pub float16: *mut PyTypeObject,
     pub int64: *mut PyTypeObject,
     pub int32: *mut PyTypeObject,
+    pub int16: *mut PyTypeObject,
     pub int8: *mut PyTypeObject,
     pub uint64: *mut PyTypeObject,
     pub uint32: *mut PyTypeObject,
+    pub uint16: *mut PyTypeObject,
     pub uint8: *mut PyTypeObject,
     pub bool_: *mut PyTypeObject,
 }
@@ -166,14 +169,17 @@ unsafe fn load_numpy_types() -> Option<NumpyTypes> {
 
     let types = Some(NumpyTypes {
         array: look_up_numpy_type(numpy, "ndarray\0"),
+        float16: look_up_numpy_type(numpy, "float16\0"),
         float32: look_up_numpy_type(numpy, "float32\0"),
         float64: look_up_numpy_type(numpy, "float64\0"),
         int8: look_up_numpy_type(numpy, "int8\0"),
+        int16: look_up_numpy_type(numpy, "int16\0"),
         int32: look_up_numpy_type(numpy, "int32\0"),
         int64: look_up_numpy_type(numpy, "int64\0"),
+        uint8: look_up_numpy_type(numpy, "uint8\0"),
+        uint16: look_up_numpy_type(numpy, "uint16\0"),
         uint32: look_up_numpy_type(numpy, "uint32\0"),
         uint64: look_up_numpy_type(numpy, "uint64\0"),
-        uint8: look_up_numpy_type(numpy, "uint8\0"),
         bool_: look_up_numpy_type(numpy, "bool_\0"),
     });
     Py_XDECREF(numpy);

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -72,6 +72,24 @@ class NumpyTests(unittest.TestCase):
             b"[0,255]",
         )
 
+    def test_numpy_array_d1_i16(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array([-32768, 32767], numpy.int16),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b"[-128,127]",
+        )
+
+    def test_numpy_array_d1_u16(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array([0, 65535], numpy.uint16),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b"[0,255]",
+        )
+
     def test_numpy_array_d1_i32(self):
         self.assertEqual(
             orjson.dumps(
@@ -88,6 +106,15 @@ class NumpyTests(unittest.TestCase):
                 option=orjson.OPT_SERIALIZE_NUMPY,
             ),
             b"[0,4294967295]",
+        )
+
+    def test_numpy_array_d1_f16(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array([1.0, 6.55e4], numpy.float16),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b"[1.0,3.4028235e38]",
         )
 
     def test_numpy_array_d1_f32(self):
@@ -148,6 +175,24 @@ class NumpyTests(unittest.TestCase):
         self.assertEqual(
             orjson.dumps(
                 numpy.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], numpy.uint8),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b"[[[1,2],[3,4]],[[5,6],[7,8]]]",
+        )
+
+    def test_numpy_array_d3_i16(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], numpy.int16),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b"[[[1,2],[3,4]],[[5,6],[7,8]]]",
+        )
+
+    def test_numpy_array_d3_u16(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], numpy.uint16),
                 option=orjson.OPT_SERIALIZE_NUMPY,
             ),
             b"[[[1,2],[3,4]],[[5,6],[7,8]]]",
@@ -371,8 +416,21 @@ class NumpyTests(unittest.TestCase):
             b"127",
         )
         self.assertEqual(
-            orjson.dumps(numpy.int8(--128), option=orjson.OPT_SERIALIZE_NUMPY),
+            orjson.dumps(numpy.int8(-128), option=orjson.OPT_SERIALIZE_NUMPY),
             b"-128",
+        )
+
+    def test_numpy_scalar_int16(self):
+        self.assertEqual(
+            orjson.dumps(numpy.int16(0), option=orjson.OPT_SERIALIZE_NUMPY), b"0"
+        )
+        self.assertEqual(
+            orjson.dumps(numpy.int16(32767), option=orjson.OPT_SERIALIZE_NUMPY),
+            b"32767",
+        )
+        self.assertEqual(
+            orjson.dumps(numpy.int16(-32768), option=orjson.OPT_SERIALIZE_NUMPY),
+            b"-32768",
         )
 
     def test_numpy_scalar_int32(self):
@@ -411,6 +469,15 @@ class NumpyTests(unittest.TestCase):
             b"255",
         )
 
+    def test_numpy_scalar_uint16(self):
+        self.assertEqual(
+            orjson.dumps(numpy.uint16(0), option=orjson.OPT_SERIALIZE_NUMPY), b"0"
+        )
+        self.assertEqual(
+            orjson.dumps(numpy.uint16(65535), option=orjson.OPT_SERIALIZE_NUMPY),
+            b"65535",
+        )
+
     def test_numpy_scalar_uint32(self):
         self.assertEqual(
             orjson.dumps(numpy.uint32(0), option=orjson.OPT_SERIALIZE_NUMPY), b"0"
@@ -429,6 +496,11 @@ class NumpyTests(unittest.TestCase):
                 numpy.uint64(18446744073709551615), option=orjson.OPT_SERIALIZE_NUMPY
             ),
             b"18446744073709551615",
+        )
+
+    def test_numpy_scalar_float16(self):
+        self.assertEqual(
+            orjson.dumps(numpy.float16(1.0), option=orjson.OPT_SERIALIZE_NUMPY), b"1.0"
         )
 
     def test_numpy_scalar_float32(self):


### PR DESCRIPTION
I added `np.int16`, `np.uint16` and `np.float16` support. I'm not familiar with rust, so I appreciate your feedback. Thanks.