### PR TITLE
Serialization of numpy datetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46016233fc1bb55c23b856fe556b7db6ccd05119a0a392e04f0b3b7c79058f16"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +57,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -129,6 +145,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +176,7 @@ dependencies = [
  "ahash",
  "associative-cache",
  "bytecount",
+ "chrono",
  "encoding_rs",
  "inlinable_string",
  "itoa",
@@ -255,9 +291,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ classifiers = [
 ahash = { version = "0.7", default_features = false }
 associative-cache = { version = "1" }
 bytecount = { version = "^0.6.2", default_features = false, features = ["generic-simd", "runtime-dispatch-simd"] }
+chrono = { version = "0.4.19", default_features = false }
 encoding_rs = { version = "0.8", default_features = false }
 inlinable_string = { version = "0.1" }
 itoa = { version = "0.4", default_features = false }

--- a/src/serialize/datetime.rs
+++ b/src/serialize/datetime.rs
@@ -2,10 +2,9 @@
 
 use crate::exc::*;
 use crate::opt::*;
+use crate::serialize::datetimelike::{DateTimeBuffer, DateTimeError, DateTimeLike, Offset};
 use crate::typeref::*;
 use serde::ser::{Serialize, Serializer};
-
-pub type DateTimeBuffer = smallvec::SmallVec<[u8; 32]>;
 
 macro_rules! write_double_digit {
     ($buf:ident, $value:ident) => {
@@ -126,10 +125,6 @@ impl<'p> Serialize for Time {
     }
 }
 
-pub enum DateTimeError {
-    LibraryUnsupported,
-}
-
 pub struct DateTime {
     ptr: *mut pyo3::ffi::PyObject,
     opts: Opt,
@@ -142,124 +137,75 @@ impl DateTime {
             opts: opts,
         }
     }
-    pub fn write_buf(&self, buf: &mut DateTimeBuffer) -> Result<(), DateTimeError> {
-        let has_tz = unsafe { (*(self.ptr as *mut pyo3::ffi::PyDateTime_DateTime)).hastzinfo == 1 };
-        let offset_day: i32;
-        let mut offset_second: i32;
-        if !has_tz {
-            offset_second = 0;
-            offset_day = 0;
+}
+
+macro_rules! pydatetime_get {
+    ($fn: ident, $pyfn: ident, $ty: ident) => {
+        fn $fn(&self) -> $ty {
+            ffi!($pyfn(self.ptr)) as $ty
+        }
+    };
+}
+
+impl DateTimeLike for DateTime {
+    pydatetime_get!(year, PyDateTime_GET_YEAR, i32);
+    pydatetime_get!(month, PyDateTime_GET_MONTH, u8);
+    pydatetime_get!(day, PyDateTime_GET_DAY, u8);
+    pydatetime_get!(hour, PyDateTime_DATE_GET_HOUR, u8);
+    pydatetime_get!(minute, PyDateTime_DATE_GET_MINUTE, u8);
+    pydatetime_get!(second, PyDateTime_DATE_GET_SECOND, u8);
+    pydatetime_get!(microsecond, PyDateTime_DATE_GET_MICROSECOND, u32);
+
+    fn millisecond(&self) -> u32 {
+        self.microsecond() / 1_000
+    }
+
+    fn nanosecond(&self) -> u32 {
+        self.microsecond() * 1_000
+    }
+
+    fn has_tz(&self) -> bool {
+        unsafe { (*(self.ptr as *mut pyo3::ffi::PyDateTime_DateTime)).hastzinfo == 1 }
+    }
+
+    fn offset(&self) -> Result<Offset, DateTimeError> {
+        if !self.has_tz() {
+            Ok(Offset::default())
         } else {
             let tzinfo = ffi!(PyDateTime_DATE_GET_TZINFO(self.ptr));
             if ffi!(PyObject_HasAttr(tzinfo, CONVERT_METHOD_STR)) == 1 {
                 // pendulum
-                let offset = call_method!(self.ptr, UTCOFFSET_METHOD_STR);
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
-                offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
-                ffi!(Py_DECREF(offset));
+                let py_offset = call_method!(self.ptr, UTCOFFSET_METHOD_STR);
+                let offset = Offset {
+                    second: ffi!(PyDateTime_DELTA_GET_SECONDS(py_offset)) as i32,
+                    day: ffi!(PyDateTime_DELTA_GET_DAYS(py_offset)),
+                };
+                ffi!(Py_DECREF(py_offset));
+                Ok(offset)
             } else if ffi!(PyObject_HasAttr(tzinfo, NORMALIZE_METHOD_STR)) == 1 {
                 // pytz
                 let method_ptr = call_method!(tzinfo, NORMALIZE_METHOD_STR, self.ptr);
-                let offset = call_method!(method_ptr, UTCOFFSET_METHOD_STR);
+                let py_offset = call_method!(method_ptr, UTCOFFSET_METHOD_STR);
                 ffi!(Py_DECREF(method_ptr));
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
-                offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
-                ffi!(Py_DECREF(offset));
+                let offset = Offset {
+                    second: ffi!(PyDateTime_DELTA_GET_SECONDS(py_offset)) as i32,
+                    day: ffi!(PyDateTime_DELTA_GET_DAYS(py_offset)),
+                };
+                ffi!(Py_DECREF(py_offset));
+                Ok(offset)
             } else if ffi!(PyObject_HasAttr(tzinfo, DST_STR)) == 1 {
                 // dateutil/arrow, datetime.timezone.utc
-                let offset = call_method!(tzinfo, UTCOFFSET_METHOD_STR, self.ptr);
-                offset_second = ffi!(PyDateTime_DELTA_GET_SECONDS(offset)) as i32;
-                offset_day = ffi!(PyDateTime_DELTA_GET_DAYS(offset));
-                ffi!(Py_DECREF(offset));
+                let py_offset = call_method!(tzinfo, UTCOFFSET_METHOD_STR, self.ptr);
+                let offset = Offset {
+                    second: ffi!(PyDateTime_DELTA_GET_SECONDS(py_offset)) as i32,
+                    day: ffi!(PyDateTime_DELTA_GET_DAYS(py_offset)),
+                };
+                ffi!(Py_DECREF(py_offset));
+                Ok(offset)
             } else {
-                return Err(DateTimeError::LibraryUnsupported);
-            }
-        };
-        {
-            let year = ffi!(PyDateTime_GET_YEAR(self.ptr)) as i32;
-            let mut yearbuf = itoa::Buffer::new();
-            let formatted = yearbuf.format(year);
-            if unlikely!(year < 1000) {
-                // date-fullyear   = 4DIGIT
-                buf.extend_from_slice(&[b'0', b'0', b'0', b'0'][..(4 - formatted.len())]);
-            }
-            buf.extend_from_slice(formatted.as_bytes());
-        }
-        buf.push(b'-');
-        {
-            let month = ffi!(PyDateTime_GET_MONTH(self.ptr)) as u8;
-            write_double_digit!(buf, month);
-        }
-        buf.push(b'-');
-        {
-            let day = ffi!(PyDateTime_GET_DAY(self.ptr)) as u8;
-            write_double_digit!(buf, day);
-        }
-        buf.push(b'T');
-        {
-            let hour = ffi!(PyDateTime_DATE_GET_HOUR(self.ptr)) as u8;
-            write_double_digit!(buf, hour);
-        }
-        buf.push(b':');
-        {
-            let minute = ffi!(PyDateTime_DATE_GET_MINUTE(self.ptr)) as u8;
-            write_double_digit!(buf, minute);
-        }
-        buf.push(b':');
-        {
-            let second = ffi!(PyDateTime_DATE_GET_SECOND(self.ptr)) as u8;
-            write_double_digit!(buf, second);
-        }
-        if self.opts & OMIT_MICROSECONDS == 0 {
-            let microsecond = ffi!(PyDateTime_DATE_GET_MICROSECOND(self.ptr)) as u32;
-            write_microsecond!(buf, microsecond);
-        }
-        if has_tz || self.opts & NAIVE_UTC != 0 {
-            if offset_second == 0 {
-                if self.opts & UTC_Z != 0 {
-                    buf.push(b'Z');
-                } else {
-                    buf.extend_from_slice(&[b'+', b'0', b'0', b':', b'0', b'0']);
-                }
-            } else {
-                if offset_day == -1 {
-                    // datetime.timedelta(days=-1, seconds=68400) -> -05:00
-                    buf.push(b'-');
-                    offset_second = 86400 - offset_second;
-                } else {
-                    // datetime.timedelta(seconds=37800) -> +10:30
-                    buf.push(b'+');
-                }
-                {
-                    let offset_minute = offset_second / 60;
-                    let offset_hour = offset_minute / 60;
-                    write_double_digit!(buf, offset_hour);
-                    buf.push(b':');
-
-                    let mut offset_minute_print = offset_minute % 60;
-
-                    {
-                        // https://tools.ietf.org/html/rfc3339#section-5.8
-                        // "exactly 19 minutes and 32.13 seconds ahead of UTC"
-                        // "closest representable UTC offset"
-                        //  "+20:00"
-                        let offset_excess_second =
-                            offset_second - (offset_minute_print * 60 + offset_hour * 3600);
-                        if offset_excess_second >= 30 {
-                            offset_minute_print += 1;
-                        }
-                    }
-
-                    if offset_minute_print < 10 {
-                        buf.push(b'0');
-                    }
-                    buf.extend_from_slice(
-                        itoa::Buffer::new().format(offset_minute_print).as_bytes(),
-                    );
-                }
+                Err(DateTimeError::LibraryUnsupported)
             }
         }
-        Ok(())
     }
 }
 
@@ -270,7 +216,7 @@ impl<'p> Serialize for DateTime {
         S: Serializer,
     {
         let mut buf: DateTimeBuffer = smallvec::SmallVec::with_capacity(32);
-        if self.write_buf(&mut buf).is_err() {
+        if self.write_buf(&mut buf, self.opts).is_err() {
             err!(DATETIME_LIBRARY_UNSUPPORTED)
         }
         serializer.serialize_str(str_from_slice!(buf.as_ptr(), buf.len()))

--- a/src/serialize/datetimelike.rs
+++ b/src/serialize/datetimelike.rs
@@ -1,0 +1,173 @@
+use crate::opt::*;
+
+#[derive(Debug)]
+pub enum DateTimeError {
+    LibraryUnsupported,
+}
+
+pub type DateTimeBuffer = smallvec::SmallVec<[u8; 32]>;
+
+macro_rules! write_double_digit {
+    ($buf:ident, $value:expr) => {
+        if $value < 10 {
+            $buf.push(b'0');
+        }
+        $buf.extend_from_slice(itoa::Buffer::new().format($value).as_bytes());
+    };
+}
+
+macro_rules! write_triple_digit {
+    ($buf:ident, $value:expr) => {
+        if $value < 100 {
+            $buf.push(b'0');
+        }
+        if $value < 10 {
+            $buf.push(b'0');
+        }
+        $buf.extend_from_slice(itoa::Buffer::new().format($value).as_bytes());
+    };
+}
+
+#[derive(Default)]
+pub struct Offset {
+    pub day: i32,
+    pub second: i32,
+}
+
+/// Trait providing a method to write a datetime-like object to a buffer in an RFC3339-compatible format.
+///
+/// The provided `write_buf` method does not allocate, and is faster
+/// than writing to a heap-allocated string.
+pub trait DateTimeLike {
+    /// Returns the year component of the datetime.
+    fn year(&self) -> i32;
+    /// Returns the month component of the datetime.
+    fn month(&self) -> u8;
+    /// Returns the day component of the datetime.
+    fn day(&self) -> u8;
+    /// Returns the hour component of the datetime.
+    fn hour(&self) -> u8;
+    /// Returns the minute component of the datetime.
+    fn minute(&self) -> u8;
+    /// Returns the second component of the datetime.
+    fn second(&self) -> u8;
+    /// Returns the number of milliseconds since the whole non-leap second.
+    fn millisecond(&self) -> u32;
+    /// Returns the number of microseconds since the whole non-leap second.
+    fn microsecond(&self) -> u32;
+    /// Returns the number of nanoseconds since the whole non-leap second.
+    fn nanosecond(&self) -> u32;
+
+    /// Is the object time-zone aware?
+    fn has_tz(&self) -> bool;
+
+    /// The offset of the timezone.
+    fn offset(&self) -> Result<Offset, DateTimeError>;
+
+    /// Write `self` to a buffer in RFC3339 format, using `opts` to
+    /// customise if desired.
+    fn write_buf(&self, buf: &mut DateTimeBuffer, opts: Opt) -> Result<(), DateTimeError> {
+        {
+            let year = self.year();
+            let mut yearbuf = itoa::Buffer::new();
+            let formatted = yearbuf.format(year);
+            if unlikely!(year < 1000) {
+                // date-fullyear   = 4DIGIT
+                buf.extend_from_slice(&[b'0', b'0', b'0', b'0'][..(4 - formatted.len())]);
+            }
+            buf.extend_from_slice(formatted.as_bytes());
+        }
+        buf.push(b'-');
+        {
+            write_double_digit!(buf, self.month());
+        }
+        buf.push(b'-');
+        {
+            write_double_digit!(buf, self.day());
+        }
+        buf.push(b'T');
+        {
+            write_double_digit!(buf, self.hour());
+        }
+        buf.push(b':');
+        {
+            write_double_digit!(buf, self.minute());
+        }
+        buf.push(b':');
+        {
+            write_double_digit!(buf, self.second());
+        }
+        if opts & OMIT_MICROSECONDS == 0 {
+            let microsecond = self.microsecond();
+            if microsecond != 0 {
+                {
+                    buf.push(b'.');
+                }
+                {
+                    write_triple_digit!(buf, microsecond / 1_000);
+                }
+                {
+                    write_triple_digit!(buf, microsecond % 1_000);
+                }
+                // Don't support writing nanoseconds for now.
+                // If requested, something like the following should work,
+                // and the `DateTimeBuffer` type alias should be changed to
+                // have length 35.
+                // let nanosecond = self.nanosecond();
+                // if nanosecond % 1_000 != 0 {
+                //     write_triple_digit!(buf, nanosecond % 1_000);
+                // }
+            }
+        }
+        if self.has_tz() || opts & NAIVE_UTC != 0 {
+            let offset = self.offset()?;
+            let mut offset_second = offset.second;
+            if offset_second == 0 {
+                if opts & UTC_Z != 0 {
+                    buf.push(b'Z');
+                } else {
+                    buf.extend_from_slice(&[b'+', b'0', b'0', b':', b'0', b'0']);
+                }
+            } else {
+                // This branch is only really hit by the Python datetime implementation,
+                // since numpy datetimes are all converted to UTC.
+                if offset.day == -1 {
+                    // datetime.timedelta(days=-1, seconds=68400) -> -05:00
+                    buf.push(b'-');
+                    offset_second = 86400 - offset_second;
+                } else {
+                    // datetime.timedelta(seconds=37800) -> +10:30
+                    buf.push(b'+');
+                }
+                {
+                    let offset_minute = offset_second / 60;
+                    let offset_hour = offset_minute / 60;
+                    write_double_digit!(buf, offset_hour);
+                    buf.push(b':');
+
+                    let mut offset_minute_print = offset_minute % 60;
+
+                    {
+                        // https://tools.ietf.org/html/rfc3339#section-5.8
+                        // "exactly 19 minutes and 32.13 seconds ahead of UTC"
+                        // "closest representable UTC offset"
+                        //  "+20:00"
+                        let offset_excess_second =
+                            offset_second - (offset_minute_print * 60 + offset_hour * 3600);
+                        if offset_excess_second >= 30 {
+                            offset_minute_print += 1;
+                        }
+                    }
+
+                    if offset_minute_print < 10 {
+                        buf.push(b'0');
+                    }
+                    buf.extend_from_slice(
+                        itoa::Buffer::new().format(offset_minute_print).as_bytes(),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/serialize/dict.rs
+++ b/src/serialize/dict.rs
@@ -4,6 +4,7 @@ use crate::exc::*;
 use crate::ffi::PyDict_GET_SIZE;
 use crate::opt::*;
 use crate::serialize::datetime::*;
+use crate::serialize::datetimelike::*;
 use crate::serialize::serializer::pyobject_to_obtype;
 use crate::serialize::serializer::*;
 use crate::serialize::uuid::*;
@@ -236,7 +237,7 @@ impl DictNonStrKey {
             ObType::Datetime => {
                 let mut buf: DateTimeBuffer = smallvec::SmallVec::with_capacity(32);
                 let dt = DateTime::new(key, opts);
-                if dt.write_buf(&mut buf).is_err() {
+                if dt.write_buf(&mut buf, opts).is_err() {
                     return Err(NonStrError::DatetimeLibraryUnsupported);
                 }
                 let key_as_str = str_from_slice!(buf.as_ptr(), buf.len());

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -2,6 +2,8 @@
 
 mod dataclass;
 mod datetime;
+#[macro_use]
+mod datetimelike;
 mod default;
 mod dict;
 mod int;

--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -1,6 +1,11 @@
-use crate::typeref::{ARRAY_STRUCT_STR, NUMPY_TYPES};
+use crate::opt::*;
+use crate::serialize::datetimelike::{DateTimeBuffer, DateTimeError, DateTimeLike, Offset};
+use crate::typeref::{ARRAY_STRUCT_STR, DESCR_STR, DTYPE_STR, NUMPY_TYPES};
+use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
 use pyo3::ffi::*;
-use serde::ser::{Serialize, SerializeSeq, Serializer};
+use serde::ser::{self, Serialize, SerializeSeq, Serializer};
+use std::convert::TryInto;
+use std::fmt;
 use std::ops::DerefMut;
 use std::os::raw::{c_char, c_int, c_void};
 
@@ -24,6 +29,7 @@ pub fn is_numpy_scalar(ob_type: *mut PyTypeObject) -> bool {
             || ob_type == scalar_types.uint32
             || ob_type == scalar_types.uint8
             || ob_type == scalar_types.bool_
+            || ob_type == scalar_types.datetime64
     }
 }
 
@@ -63,6 +69,7 @@ pub struct PyArrayInterface {
 #[derive(Clone, Copy)]
 pub enum ItemType {
     BOOL,
+    DATETIME64(NumpyDatetimeUnit),
     F32,
     F64,
     I8,
@@ -74,9 +81,13 @@ pub enum ItemType {
 }
 
 impl ItemType {
-    fn find(array: *mut PyArrayInterface) -> Option<ItemType> {
+    fn find(array: *mut PyArrayInterface, ptr: *mut PyObject) -> Option<ItemType> {
         match unsafe { ((*array).typekind, (*array).itemsize) } {
             (098, 1) => Some(ItemType::BOOL),
+            (077, 8) => {
+                let unit = NumpyDatetimeUnit::from_pyobject(ptr);
+                Some(ItemType::DATETIME64(unit))
+            }
             (102, 4) => Some(ItemType::F32),
             (102, 8) => Some(ItemType::F64),
             (105, 1) => Some(ItemType::I8),
@@ -109,11 +120,12 @@ pub struct NumpyArray {
     depth: usize,
     capsule: *mut PyCapsule,
     kind: ItemType,
+    opts: Opt,
 }
 
 impl<'a> NumpyArray {
     #[inline(never)]
-    pub fn new(ptr: *mut PyObject) -> Result<Self, PyArrayError> {
+    pub fn new(ptr: *mut PyObject, opts: Opt) -> Result<Self, PyArrayError> {
         let capsule = ffi!(PyObject_GetAttr(ptr, ARRAY_STRUCT_STR));
         let array = unsafe { (*(capsule as *mut PyCapsule)).pointer as *mut PyArrayInterface };
         if unsafe { (*array).two != 2 } {
@@ -127,7 +139,7 @@ impl<'a> NumpyArray {
             if num_dimensions == 0 {
                 return Err(PyArrayError::UnsupportedDataType);
             }
-            match ItemType::find(array) {
+            match ItemType::find(array, ptr) {
                 None => Err(PyArrayError::UnsupportedDataType),
                 Some(kind) => {
                     let mut pyarray = NumpyArray {
@@ -137,6 +149,7 @@ impl<'a> NumpyArray {
                         depth: 0,
                         capsule: capsule as *mut PyCapsule,
                         kind: kind,
+                        opts,
                     };
                     if pyarray.dimensions() > 1 {
                         pyarray.build();
@@ -155,6 +168,7 @@ impl<'a> NumpyArray {
             depth: self.depth + 1,
             capsule: self.capsule,
             kind: self.kind,
+            opts: self.opts,
         };
         arr.build();
         arr
@@ -281,6 +295,15 @@ impl<'p> Serialize for NumpyArray {
                         let slice: &[u8] = slice!(data_ptr as *const u8, num_items);
                         for &each in slice.iter() {
                             seq.serialize_element(&DataTypeBOOL { obj: each }).unwrap();
+                        }
+                    }
+                    ItemType::DATETIME64(unit) => {
+                        let slice: &[i64] = slice!(data_ptr as *const i64, num_items);
+                        for &each in slice.iter() {
+                            let dt = unit
+                                .datetime(each, self.opts)
+                                .map_err(NumpyDateTimeError::into_serde_err)?;
+                            seq.serialize_element(&dt).unwrap();
                         }
                     }
                 }
@@ -416,14 +439,14 @@ impl<'p> Serialize for DataTypeBOOL {
     }
 }
 
-#[repr(transparent)]
 pub struct NumpyScalar {
     pub ptr: *mut pyo3::ffi::PyObject,
+    pub opts: Opt,
 }
 
 impl NumpyScalar {
-    pub fn new(ptr: *mut PyObject) -> Self {
-        NumpyScalar { ptr }
+    pub fn new(ptr: *mut PyObject, opts: Opt) -> Self {
+        NumpyScalar { ptr, opts }
     }
 }
 
@@ -453,6 +476,13 @@ impl<'p> Serialize for NumpyScalar {
                 (*(self.ptr as *mut NumpyUint8)).serialize(serializer)
             } else if ob_type == scalar_types.bool_ {
                 (*(self.ptr as *mut NumpyBool)).serialize(serializer)
+            } else if ob_type == scalar_types.datetime64 {
+                let unit = NumpyDatetimeUnit::from_pyobject(self.ptr);
+                let obj = &*(self.ptr as *mut NumpyDatetime64);
+                let dt = unit
+                    .datetime(obj.value, self.opts)
+                    .map_err(NumpyDateTimeError::into_serde_err)?;
+                dt.serialize(serializer)
             } else {
                 unreachable!()
             }
@@ -601,5 +631,215 @@ impl<'p> Serialize for NumpyBool {
         S: Serializer,
     {
         serializer.serialize_bool(self.value)
+    }
+}
+
+/// This mimicks the units supported by numpy's datetime64 type.
+///
+/// See
+/// https://github.com/numpy/numpy/blob/fc8e3bbe419748ac5c6b7f3d0845e4bafa74644b/numpy/core/include/numpy/ndarraytypes.h#L268-L282.
+#[derive(Clone, Copy, Debug)]
+pub enum NumpyDatetimeUnit {
+    Years,
+    Months,
+    Weeks,
+    Days,
+    Hours,
+    Minutes,
+    Seconds,
+    Milliseconds,
+    Microseconds,
+    Nanoseconds,
+    Picoseconds,
+    Femtoseconds,
+    Attoseconds,
+    Generic,
+}
+
+impl fmt::Display for NumpyDatetimeUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unit = match self {
+            Self::Years => "years",
+            Self::Months => "months",
+            Self::Weeks => "weeks",
+            Self::Days => "days",
+            Self::Hours => "hours",
+            Self::Minutes => "minutes",
+            Self::Seconds => "seconds",
+            Self::Milliseconds => "milliseconds",
+            Self::Microseconds => "microseconds",
+            Self::Nanoseconds => "nanoseconds",
+            Self::Picoseconds => "picoseconds",
+            Self::Femtoseconds => "femtoseconds",
+            Self::Attoseconds => "attoseconds",
+            Self::Generic => "generic",
+        };
+        write!(f, "{}", unit)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NumpyDateTimeError {
+    UnsupportedUnit(NumpyDatetimeUnit),
+    Unrepresentable { unit: NumpyDatetimeUnit, val: i64 },
+}
+
+impl NumpyDateTimeError {
+    fn into_serde_err<T: ser::Error>(self) -> T {
+        let err = match self {
+            Self::UnsupportedUnit(unit) => format!("unsupported numpy.datetime64 unit: {}", unit),
+            Self::Unrepresentable { unit, val } => {
+                format!("unrepresentable numpy.datetime64: {} {}", val, unit)
+            }
+        };
+        ser::Error::custom(err)
+    }
+}
+
+impl NumpyDatetimeUnit {
+    /// Create a `NumpyDatetimeUnit` from a pointer to a Python object holding a
+    /// numpy array.
+    ///
+    /// This function must only be called with pointers to numpy arrays.
+    ///
+    /// We need to look inside the `obj.dtype.descr` attribute of the Python
+    /// object rather than using the `descr` field of the `__array_struct__`
+    /// because that field isn't populated for datetime64 arrays; see
+    /// https://github.com/numpy/numpy/issues/5350.
+    fn from_pyobject(ptr: *mut PyObject) -> Self {
+        let dtype = ffi!(PyObject_GetAttr(ptr, DTYPE_STR));
+        let descr = ffi!(PyObject_GetAttr(dtype, DESCR_STR));
+        let el0 = ffi!(PyList_GET_ITEM(descr, 0));
+        let descr_str = ffi!(PyTuple_GET_ITEM(el0, 1));
+        let mut str_size: pyo3::ffi::Py_ssize_t = 0;
+        let uni = crate::unicode::read_utf8_from_str(descr_str, &mut str_size);
+        let fmt = str_from_slice!(uni, str_size);
+        // unit descriptions are found at
+        // https://github.com/numpy/numpy/blob/b235f9e701e14ed6f6f6dcba885f7986a833743f/numpy/core/src/multiarray/datetime.c#L79-L96.
+        match &fmt[4..fmt.len() - 1] {
+            "Y" => Self::Years,
+            "M" => Self::Months,
+            "W" => Self::Weeks,
+            "D" => Self::Days,
+            "h" => Self::Hours,
+            "m" => Self::Minutes,
+            "s" => Self::Seconds,
+            "ms" => Self::Milliseconds,
+            "us" => Self::Microseconds,
+            "ns" => Self::Nanoseconds,
+            "ps" => Self::Picoseconds,
+            "fs" => Self::Femtoseconds,
+            "as" => Self::Attoseconds,
+            "generic" => Self::Generic,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Return a `NumpyDatetime64Repr` for a value in array with this unit.
+    ///
+    /// Returns an `Err(NumpyDateTimeError)` if the value is invalid for this unit.
+    fn datetime(&self, val: i64, opts: Opt) -> Result<NumpyDatetime64Repr, NumpyDateTimeError> {
+        match self {
+            Self::Years => Ok(NaiveDate::from_ymd(
+                (val + 1970)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+                1,
+                1,
+            )
+            .and_hms(0, 0, 0)),
+            Self::Months => Ok(NaiveDate::from_ymd(
+                (val / 12 + 1970)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+                (val % 12 + 1)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+                1,
+            )
+            .and_hms(0, 0, 0)),
+            Self::Weeks => Ok(NaiveDateTime::from_timestamp(val * 7 * 24 * 60 * 60, 0)),
+            Self::Days => Ok(NaiveDateTime::from_timestamp(val * 24 * 60 * 60, 0)),
+            Self::Hours => Ok(NaiveDateTime::from_timestamp(val * 60 * 60, 0)),
+            Self::Minutes => Ok(NaiveDateTime::from_timestamp(val * 60, 0)),
+            Self::Seconds => Ok(NaiveDateTime::from_timestamp(val, 0)),
+            Self::Milliseconds => Ok(NaiveDateTime::from_timestamp(
+                val / 1_000,
+                (val % 1_000 * 1_000_000)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+            )),
+            Self::Microseconds => Ok(NaiveDateTime::from_timestamp(
+                val / 1_000_000,
+                (val % 1_000_000 * 1_000)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+            )),
+            Self::Nanoseconds => Ok(NaiveDateTime::from_timestamp(
+                val / 1_000_000_000,
+                (val % 1_000_000_000)
+                    .try_into()
+                    .map_err(|_| NumpyDateTimeError::Unrepresentable { unit: *self, val })?,
+            )),
+            _ => Err(NumpyDateTimeError::UnsupportedUnit(*self)),
+        }
+        .map(|dt| NumpyDatetime64Repr { dt, opts })
+    }
+}
+
+#[repr(C)]
+pub struct NumpyDatetime64 {
+    pub ob_refcnt: Py_ssize_t,
+    pub ob_type: *mut PyTypeObject,
+    pub value: i64,
+}
+
+macro_rules! forward_inner {
+    ($meth: ident, $ty: ident) => {
+        fn $meth(&self) -> $ty {
+            self.dt.$meth() as $ty
+        }
+    };
+}
+
+struct NumpyDatetime64Repr {
+    dt: NaiveDateTime,
+    opts: Opt,
+}
+
+impl DateTimeLike for NumpyDatetime64Repr {
+    forward_inner!(year, i32);
+    forward_inner!(month, u8);
+    forward_inner!(day, u8);
+    forward_inner!(hour, u8);
+    forward_inner!(minute, u8);
+    forward_inner!(second, u8);
+    forward_inner!(nanosecond, u32);
+
+    fn millisecond(&self) -> u32 {
+        self.nanosecond() / 1_000_000
+    }
+
+    fn microsecond(&self) -> u32 {
+        self.nanosecond() / 1_000
+    }
+
+    fn has_tz(&self) -> bool {
+        false
+    }
+
+    fn offset(&self) -> Result<Offset, DateTimeError> {
+        Ok(Offset::default())
+    }
+}
+
+impl Serialize for NumpyDatetime64Repr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut buf = DateTimeBuffer::with_capacity(32);
+        self.write_buf(&mut buf, self.opts).unwrap();
+        serializer.collect_str(str_from_slice!(buf.as_ptr(), buf.len()))
     }
 }

--- a/src/serialize/serializer.rs
+++ b/src/serialize/serializer.rs
@@ -291,7 +291,7 @@ impl<'p> Serialize for PyObjectSerializer {
                 )
                 .serialize(serializer)
             }
-            ObType::NumpyArray => match NumpyArray::new(self.ptr) {
+            ObType::NumpyArray => match NumpyArray::new(self.ptr, self.opts) {
                 Ok(val) => val.serialize(serializer),
                 Err(PyArrayError::Malformed) => err!("numpy array is malformed"),
                 Err(PyArrayError::NotContiguous) | Err(PyArrayError::UnsupportedDataType)
@@ -313,7 +313,7 @@ impl<'p> Serialize for PyObjectSerializer {
                     err!("unsupported datatype in numpy array")
                 }
             },
-            ObType::NumpyScalar => NumpyScalar::new(self.ptr).serialize(serializer),
+            ObType::NumpyScalar => NumpyScalar::new(self.ptr, self.opts).serialize(serializer),
             ObType::Unknown => DefaultSerializer::new(
                 self.ptr,
                 self.opts,

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -18,6 +18,7 @@ pub struct NumpyTypes {
     pub uint32: *mut PyTypeObject,
     pub uint8: *mut PyTypeObject,
     pub bool_: *mut PyTypeObject,
+    pub datetime64: *mut PyTypeObject,
 }
 
 pub static mut NONE: *mut PyObject = 0 as *mut PyObject;
@@ -54,6 +55,8 @@ pub static mut DICT_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut DATACLASS_FIELDS_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut FIELD_TYPE_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut ARRAY_STRUCT_STR: *mut PyObject = 0 as *mut PyObject;
+pub static mut DTYPE_STR: *mut PyObject = 0 as *mut PyObject;
+pub static mut DESCR_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut VALUE_STR: *mut PyObject = 0 as *mut PyObject;
 pub static mut STR_HASH_FUNCTION: Option<hashfunc> = None;
 pub static mut DEFAULT: *mut PyObject = 0 as *mut PyObject;
@@ -122,6 +125,8 @@ pub fn init_typerefs() {
         FIELD_TYPE_STR = PyUnicode_InternFromString("_field_type\0".as_ptr() as *const c_char);
         ARRAY_STRUCT_STR =
             pyo3::ffi::PyUnicode_InternFromString("__array_struct__\0".as_ptr() as *const c_char);
+        DTYPE_STR = pyo3::ffi::PyUnicode_InternFromString("dtype\0".as_ptr() as *const c_char);
+        DESCR_STR = pyo3::ffi::PyUnicode_InternFromString("descr\0".as_ptr() as *const c_char);
         VALUE_STR = pyo3::ffi::PyUnicode_InternFromString("value\0".as_ptr() as *const c_char);
         DEFAULT = PyUnicode_InternFromString("default\0".as_ptr() as *const c_char);
         OPTION = PyUnicode_InternFromString("option\0".as_ptr() as *const c_char);
@@ -175,6 +180,7 @@ unsafe fn load_numpy_types() -> Option<NumpyTypes> {
         uint64: look_up_numpy_type(numpy, "uint64\0"),
         uint8: look_up_numpy_type(numpy, "uint8\0"),
         bool_: look_up_numpy_type(numpy, "bool_\0"),
+        datetime64: look_up_numpy_type(numpy, "datetime64\0"),
     });
     Py_XDECREF(numpy);
     types

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -117,6 +117,165 @@ class NumpyTests(unittest.TestCase):
             b"[true,false,false,true]",
         )
 
+    def test_numpy_array_d1_datetime64_years(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("1"),
+                        numpy.datetime64("970"),
+                        numpy.datetime64("1920"),
+                        numpy.datetime64("1971"),
+                        numpy.datetime64("2021"),
+                        numpy.datetime64("2022"),
+                        numpy.datetime64("2023"),
+                        numpy.datetime64("9999"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["0001-01-01T00:00:00","0970-01-01T00:00:00","1920-01-01T00:00:00","1971-01-01T00:00:00","2021-01-01T00:00:00","2022-01-01T00:00:00","2023-01-01T00:00:00","9999-01-01T00:00:00"]',
+        )
+
+    def test_numpy_array_d1_datetime64_months(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01"),
+                        numpy.datetime64("2022-01"),
+                        numpy.datetime64("2023-01"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2022-01-01T00:00:00","2023-01-01T00:00:00"]',
+        )
+
+    def test_numpy_array_d1_datetime64_days(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01"),
+                        numpy.datetime64("2021-01-01"),
+                        numpy.datetime64("2021-01-01"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:00:00","2021-01-01T00:00:00"]',
+        )
+
+    def test_numpy_array_d1_datetime64_hours(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00"),
+                        numpy.datetime64("2021-01-01T01"),
+                        numpy.datetime64("2021-01-01T02"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T01:00:00","2021-01-01T02:00:00"]',
+        )
+
+    def test_numpy_array_d1_datetime64_minutes(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00"),
+                        numpy.datetime64("2021-01-01T00:01"),
+                        numpy.datetime64("2021-01-01T00:02"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:01:00","2021-01-01T00:02:00"]',
+        )
+
+    def test_numpy_array_d1_datetime64_seconds(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00:00"),
+                        numpy.datetime64("2021-01-01T00:00:01"),
+                        numpy.datetime64("2021-01-01T00:00:02"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:00:01","2021-01-01T00:00:02"]',
+        )
+
+    def test_numpy_array_d1_datetime64_milliseconds(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00:00"),
+                        numpy.datetime64("2021-01-01T00:00:00.172"),
+                        numpy.datetime64("2021-01-01T00:00:00.567"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:00:00.172000","2021-01-01T00:00:00.567000"]',
+        )
+
+    def test_numpy_array_d1_datetime64_microseconds(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00:00"),
+                        numpy.datetime64("2021-01-01T00:00:00.172"),
+                        numpy.datetime64("2021-01-01T00:00:00.567891"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:00:00.172000","2021-01-01T00:00:00.567891"]',
+        )
+
+    def test_numpy_array_d1_datetime64_nanoseconds(self):
+        self.assertEqual(
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00:00"),
+                        numpy.datetime64("2021-01-01T00:00:00.172"),
+                        numpy.datetime64("2021-01-01T00:00:00.567891234"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'["2021-01-01T00:00:00","2021-01-01T00:00:00.172000","2021-01-01T00:00:00.567891"]',
+        )
+
+    def test_numpy_array_d1_datetime64_picoseconds(self):
+        try:
+            orjson.dumps(
+                numpy.array(
+                    [
+                        numpy.datetime64("2021-01-01T00:00:00"),
+                        numpy.datetime64("2021-01-01T00:00:00.172"),
+                        numpy.datetime64("2021-01-01T00:00:00.567891234567"),
+                    ]
+                ),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            )
+            assert False
+        except TypeError as exc:
+            self.assertEqual(
+                str(exc),
+                "unsupported numpy.datetime64 unit: picoseconds",
+            )
+
     def test_numpy_array_d2_i64(self):
         self.assertEqual(
             orjson.dumps(
@@ -450,4 +609,82 @@ class NumpyTests(unittest.TestCase):
                 option=orjson.OPT_SERIALIZE_NUMPY,
             ),
             b'{"a":true,"b":false}',
+        )
+
+    def test_numpy_datetime(self):
+        self.assertEqual(
+            orjson.dumps(
+                {
+                    "year": numpy.datetime64("2021"),
+                    "month": numpy.datetime64("2021-01"),
+                    "day": numpy.datetime64("2021-01-01"),
+                    "hour": numpy.datetime64("2021-01-01T00"),
+                    "minute": numpy.datetime64("2021-01-01T00:00"),
+                    "second": numpy.datetime64("2021-01-01T00:00:00"),
+                    "milli": numpy.datetime64("2021-01-01T00:00:00.172"),
+                    "micro": numpy.datetime64("2021-01-01T00:00:00.172576"),
+                    "nano": numpy.datetime64("2021-01-01T00:00:00.172576789"),
+                },
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            ),
+            b'{"year":"2021-01-01T00:00:00","month":"2021-01-01T00:00:00","day":"2021-01-01T00:00:00","hour":"2021-01-01T00:00:00","minute":"2021-01-01T00:00:00","second":"2021-01-01T00:00:00","milli":"2021-01-01T00:00:00.172000","micro":"2021-01-01T00:00:00.172576","nano":"2021-01-01T00:00:00.172576"}',
+        )
+
+    def test_numpy_datetime_naive_utc(self):
+        self.assertEqual(
+            orjson.dumps(
+                {
+                    "year": numpy.datetime64("2021"),
+                    "month": numpy.datetime64("2021-01"),
+                    "day": numpy.datetime64("2021-01-01"),
+                    "hour": numpy.datetime64("2021-01-01T00"),
+                    "minute": numpy.datetime64("2021-01-01T00:00"),
+                    "second": numpy.datetime64("2021-01-01T00:00:00"),
+                    "milli": numpy.datetime64("2021-01-01T00:00:00.172"),
+                    "micro": numpy.datetime64("2021-01-01T00:00:00.172576"),
+                    "nano": numpy.datetime64("2021-01-01T00:00:00.172576789"),
+                },
+                option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NAIVE_UTC,
+            ),
+            b'{"year":"2021-01-01T00:00:00+00:00","month":"2021-01-01T00:00:00+00:00","day":"2021-01-01T00:00:00+00:00","hour":"2021-01-01T00:00:00+00:00","minute":"2021-01-01T00:00:00+00:00","second":"2021-01-01T00:00:00+00:00","milli":"2021-01-01T00:00:00.172000+00:00","micro":"2021-01-01T00:00:00.172576+00:00","nano":"2021-01-01T00:00:00.172576+00:00"}',
+        )
+
+    def test_numpy_datetime_naive_utc_utc_z(self):
+        self.assertEqual(
+            orjson.dumps(
+                {
+                    "year": numpy.datetime64("2021"),
+                    "month": numpy.datetime64("2021-01"),
+                    "day": numpy.datetime64("2021-01-01"),
+                    "hour": numpy.datetime64("2021-01-01T00"),
+                    "minute": numpy.datetime64("2021-01-01T00:00"),
+                    "second": numpy.datetime64("2021-01-01T00:00:00"),
+                    "milli": numpy.datetime64("2021-01-01T00:00:00.172"),
+                    "micro": numpy.datetime64("2021-01-01T00:00:00.172576"),
+                    "nano": numpy.datetime64("2021-01-01T00:00:00.172576789"),
+                },
+                option=orjson.OPT_SERIALIZE_NUMPY
+                | orjson.OPT_NAIVE_UTC
+                | orjson.OPT_UTC_Z,
+            ),
+            b'{"year":"2021-01-01T00:00:00Z","month":"2021-01-01T00:00:00Z","day":"2021-01-01T00:00:00Z","hour":"2021-01-01T00:00:00Z","minute":"2021-01-01T00:00:00Z","second":"2021-01-01T00:00:00Z","milli":"2021-01-01T00:00:00.172000Z","micro":"2021-01-01T00:00:00.172576Z","nano":"2021-01-01T00:00:00.172576Z"}',
+        )
+
+    def test_numpy_datetime_omit_microseconds(self):
+        self.assertEqual(
+            orjson.dumps(
+                {
+                    "year": numpy.datetime64("2021"),
+                    "month": numpy.datetime64("2021-01"),
+                    "day": numpy.datetime64("2021-01-01"),
+                    "hour": numpy.datetime64("2021-01-01T00"),
+                    "minute": numpy.datetime64("2021-01-01T00:00"),
+                    "second": numpy.datetime64("2021-01-01T00:00:00"),
+                    "milli": numpy.datetime64("2021-01-01T00:00:00.172"),
+                    "micro": numpy.datetime64("2021-01-01T00:00:00.172576"),
+                    "nano": numpy.datetime64("2021-01-01T00:00:00.172576789"),
+                },
+                option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_OMIT_MICROSECONDS,
+            ),
+            b'{"year":"2021-01-01T00:00:00","month":"2021-01-01T00:00:00","day":"2021-01-01T00:00:00","hour":"2021-01-01T00:00:00","minute":"2021-01-01T00:00:00","second":"2021-01-01T00:00:00","milli":"2021-01-01T00:00:00","micro":"2021-01-01T00:00:00","nano":"2021-01-01T00:00:00"}',
         )


### PR DESCRIPTION
WIP implementation of #182.

Currently just pulls in chrono's serde implementation and uses `Utc.timestamp_nanos`, but I imagine that should be changed. A few things are too naive and don't work right now, such as datetime64's with year, month, and pico/femto/attosecond units.

Feedback is welcome of course, or feel free to close if you're not interested in supporting this and I can maintain a fork.