### PR TITLE
Fixes for simdutf8 on ppc64le & osx-arm64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ pyo3 = { version = "^0.14.2", default_features = false, features = ["extension-m
 ryu = { version = "1", default_features = false }
 serde = { version = "1", default_features = false }
 serde_json = { version = "^1.0.66", default_features = false, features = ["std", "float_roundtrip"] }
-simdutf8 = { version = "0.1", default_features = false, optional = true }
+simdutf8 = { version = "^0.1.2", default_features = false, optional = true, features = ["aarch64_neon"] }
 smallvec = { version = "^1.6", default_features = false, features = ["union", "write"] }
 
 [profile.release]

--- a/src/deserialize/deserializer.rs
+++ b/src/deserialize/deserializer.rs
@@ -34,7 +34,7 @@ fn is_valid_utf8(buf: &[u8]) -> bool {
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 fn is_valid_utf8(buf: &[u8]) -> bool {
-    simdutf8::basic::from_utf8(buf).is_ok()
+    encoding_rs::Encoding::utf8_valid_up_to(buf) == buf.len()
 }
 
 pub fn deserialize(


### PR DESCRIPTION
Without this fix, compilation on ppc64le fails with:
```
error[E0433]: failed to resolve: use of undeclared crate or module `simdutf8`
  --> src/deserialize/deserializer.rs:37:5
   |
37 |     simdutf8::basic::from_utf8(buf).is_ok()
   |     ^^^^^^^^ use of undeclared crate or module `simdutf8`
```