### PR TITLE
adding serialization of datetime as timestamp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
     opt!(mptr, "OPT_SORT_KEYS\0", opt::SORT_KEYS);
     opt!(mptr, "OPT_STRICT_INTEGER\0", opt::STRICT_INTEGER);
     opt!(mptr, "OPT_UTC_Z\0", opt::UTC_Z);
+    opt!(mptr, "OPT_TIMESTAMP\0", opt::TIMESTAMP);
 
     typeref::init_typerefs();
 
@@ -162,7 +163,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
     };
 
     // maturin>=0.11.0 creates a python package that imports *, hiding dunder by default
-    let all: [&str; 20] = [
+    let all: [&str; 21] = [
         "__all__\0",
         "__version__\0",
         "dumps\0",
@@ -183,6 +184,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
         "OPT_SORT_KEYS\0",
         "OPT_STRICT_INTEGER\0",
         "OPT_UTC_Z\0",
+        "OPT_TIMESTAMP\0"
     ];
 
     let pyall = PyTuple_New(all.len() as isize);

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,6 +14,7 @@ pub const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub const APPEND_NEWLINE: Opt = 1 << 10;
 pub const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
+pub const TIMESTAMP: Opt = 1 << 12;
 
 // deprecated
 pub const SERIALIZE_DATACLASS: Opt = 0;
@@ -37,4 +38,5 @@ pub const MAX_OPT: i32 = (APPEND_NEWLINE
     | SERIALIZE_UUID
     | SORT_KEYS
     | STRICT_INTEGER
-    | UTC_Z) as i32;
+    | UTC_Z
+    | TIMESTAMP) as i32;

--- a/src/serialize/datetimelike.rs
+++ b/src/serialize/datetimelike.rs
@@ -54,6 +54,12 @@ macro_rules! write_triple_digit {
     };
 }
 
+macro_rules! write_any_digit {
+    ($buf:ident, $value:expr) => {
+        $buf.extend_from_slice(itoa::Buffer::new().format($value).as_bytes());
+    };
+}
+
 #[derive(Default)]
 pub struct Offset {
     pub day: i32,
@@ -83,6 +89,8 @@ pub trait DateTimeLike {
     fn microsecond(&self) -> u32;
     /// Returns the number of nanoseconds since the whole non-leap second.
     fn nanosecond(&self) -> u32;
+    /// Return POSIX timestamp corresponding to the datetime.
+    fn timestamp(&self) -> i32;
 
     /// Is the object time-zone aware?
     fn has_tz(&self) -> bool;
@@ -93,6 +101,11 @@ pub trait DateTimeLike {
     /// Write `self` to a buffer in RFC3339 format, using `opts` to
     /// customise if desired.
     fn write_buf(&self, buf: &mut DateTimeBuffer, opts: Opt) -> Result<(), DateTimeError> {
+        if opts & TIMESTAMP != 0{
+            // write datetime as UNIX timestamp
+            write_any_digit!(buf, self.timestamp());
+            return Ok(());
+        }
         {
             let year = self.year();
             let mut yearbuf = itoa::Buffer::new();

--- a/src/serialize/numpy.rs
+++ b/src/serialize/numpy.rs
@@ -832,6 +832,8 @@ impl DateTimeLike for NumpyDatetime64Repr {
     fn offset(&self) -> Result<Offset, DateTimeError> {
         Ok(Offset::default())
     }
+
+    fn timestamp(&self) -> i32 {todo!()}
 }
 
 impl Serialize for NumpyDatetime64Repr {

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -253,3 +253,8 @@ unsafe fn look_up_time_type() -> *mut PyTypeObject {
     Py_DECREF(time);
     ptr
 }
+
+
+pub static NB_DAILY_SECONDS: i32 = 86400;
+pub static NB_LEAP_YEARS_1970: i32 = 477;
+pub const DAYS_IN_MONTH:[&'static i32; 12] = [&31, &28, &31, &30, &31, &30, &31, &31, &30, &31, &30, &31];

--- a/src/util.rs
+++ b/src/util.rs
@@ -98,3 +98,19 @@ macro_rules! call_method {
         }
     };
 }
+
+
+pub trait ModuloSignedExt {
+    fn modulo(&self, n: Self) -> Self;
+}
+macro_rules! modulo_signed_ext_impl {
+    ($($t:ty)*) => ($(
+        impl ModuloSignedExt for $t {
+            #[inline]
+            fn modulo(&self, n: Self) -> Self {
+                (self % n + n) % n
+            }
+        }
+    )*)
+}
+modulo_signed_ext_impl! { i8 i16 i32 i64 }

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -93,7 +93,7 @@ class ApiTests(unittest.TestCase):
         dumps() option out of range high
         """
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=1 << 12)
+            orjson.dumps(True, option=1 << 13)
 
     def test_opts_multiple(self):
         """

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -584,6 +584,65 @@ class DatetimeTests(unittest.TestCase):
         for attr in ("year", "month", "day", "hour", "minute", "second", "microsecond"):
             self.assertEqual(getattr(obj, attr), getattr(parsed, attr))
 
+    def test_datetime_timestamp(self):
+        """
+        datetime.timestamp
+        Testing before and after Timestamp 0 (Jan 1st 1970),
+        before and after February, on leap and common years.
+        """
+        self.assertEqual(
+            orjson.dumps(
+                [
+                    datetime.datetime(
+                        1967, 1, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        1967, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        1968, 1, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        1968, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        2020, 1, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        2020, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        2021, 1, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        2021, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                ],
+                option=orjson.OPT_TIMESTAMP,
+            ),
+            b'["-94694399","-89596799","-63158399","-57974399","1577836801","1583020801","1609459201","1614556801"]',
+        )
+
+    def test_datetime_timestamp_offset(self):
+        """
+        datetime.timestamp with a tz offset
+        """
+        self.assertEqual(
+            orjson.dumps(
+                [
+                    datetime.datetime(
+                        2020, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    datetime.datetime(
+                        2020, 3, 1, 0, 0, 1, 0, tzinfo=tz.gettz("Europe/Amsterdam")
+                    ),
+                ],
+                option=orjson.OPT_TIMESTAMP,
+            ),
+            b'["1583020801","1583017201"]',
+        )
+
+
 
 class DateTests(unittest.TestCase):
     def test_date(self):


### PR DESCRIPTION
ref issue: https://github.com/ijl/orjson/issues/203  

I implemented serialization of datetime as timestamp as well some pytest. It does support utc_offset.
While benchmarking on my laptop, I observed a ~35% performance increase over default.  
  
Usage:
```
>>>orjson.dumps(
    [
        datetime.datetime(
            2020, 3, 1, 0, 0, 1, 0, tzinfo=datetime.timezone.utc
        ),
        datetime.datetime(
            2020, 3, 1, 0, 0, 1, 0, tzinfo=tz.gettz("Europe/Amsterdam")
        ),
    ],
    option=orjson.OPT_TIMESTAMP,
)
b'["1583020801","1583017201"]'
```