### PR TITLE
Special casing for deserializing empty values

### DIFF
--- a/bench/benchmark_empty.py
+++ b/bench/benchmark_empty.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from json import loads as json_loads
+
+import pytest
+
+from .data import libraries
+
+
+@pytest.mark.parametrize("data", ["[]", "{}", '""'])
+@pytest.mark.parametrize("library", libraries)
+def test_empty(benchmark, data, library):
+    dumper, loader = libraries[library]
+    benchmark.extra_info["correct"] = json_loads(dumper(loader(data))) == json_loads(
+        data
+    )
+    benchmark(loader, data)

--- a/script/pybench-empty
+++ b/script/pybench-empty
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+pytest \
+    --verbose \
+    --benchmark-min-time=1 \
+    --benchmark-max-time=5 \
+    --benchmark-disable-gc \
+    --benchmark-autosave \
+    --benchmark-save-data \
+    --random-order \
+    -k orjson \
+    "bench/benchmark_empty.py"

--- a/src/deserialize/utf8.rs
+++ b/src/deserialize/utf8.rs
@@ -31,9 +31,9 @@ fn is_valid_utf8(buf: &[u8]) -> bool {
     std::str::from_utf8(buf).is_ok()
 }
 
-pub fn read_input_to_str(
+pub fn read_input_to_buf(
     ptr: *mut pyo3::ffi::PyObject,
-) -> Result<&'static str, DeserializeError<'static>> {
+) -> Result<&'static [u8], DeserializeError<'static>> {
     let obj_type_ptr = ob_type!(ptr);
     let contents: &[u8];
     if is_type!(obj_type_ptr, STR_TYPE) {
@@ -73,9 +73,15 @@ pub fn read_input_to_str(
             ));
         }
         contents = unsafe { std::slice::from_raw_parts(buffer, length) };
-        if !is_valid_utf8(contents) {
-            return Err(DeserializeError::new(Cow::Borrowed(INVALID_STR), 0, 0, ""));
-        }
+    }
+    Ok(contents)
+}
+
+pub fn read_buf_to_str(
+    contents: &[u8]
+) -> Result<&str, DeserializeError> {
+    if !is_valid_utf8(contents) {
+        return Err(DeserializeError::new(Cow::Borrowed(INVALID_STR), 0, 0, ""));
     }
     Ok(unsafe { std::str::from_utf8_unchecked(contents) })
 }


### PR DESCRIPTION
(This PR builds on the benchmark refactorings in #221, hence it's a draft for the time being.)

I have a workload where it's likely that many of the JSON strings to be deserialized are `[]` or `{}`, and thought that it might be a good place for some optimization.

Turns out it is, a roughly 20%-30% improvement on my machine.

(Little wonder though – the comparisons compile down (as I'd expected!) to something like `cmp eax, 23899` / `cmp eax, 32123` / `cmp eax, 8738` [according to Godbolt](https://godbolt.org/z/oevz1doKe).)

```
Name (time in ns)                        Mean                    OPS (Mops/s)
----------------------------------------------------------------------------------
test_empty[orjson-""] (0010_bd79872)     61.9870 (1.0)           16.1324 (1.0)
test_empty[orjson-""] (0009_master_)     75.7611 (1.22)          13.1994 (0.82)
test_empty[orjson-[]] (0010_bd79872)     61.5401 (1.0)           16.2496 (1.0)
test_empty[orjson-[]] (0009_master_)     73.8338 (1.20)          13.5439 (0.83)
test_empty[orjson-{}] (0010_bd79872)     60.3897 (1.0)           16.5591 (1.0)
test_empty[orjson-{}] (0009_master_)     79.8558 (1.32)          12.5226 (0.76)
----------------------------------------------------------------------------------
```

I'm not sure whether these are just measurement inconsistencies or if there's e.g. some cache-related timey wimey wibbly wobbly things going on, but general `loads`es are a little (5%) slower on this for some datasets? Maybe?

```
Name (time in ms)                                    Mean                OPS
--------------------------------------------------------------------------------------
test_loads[orjson-canada.json] (0001_78f1379)     13.6616 (1.0)      73.1978 (1.0)
test_loads[orjson-canada.json] (0002_9f457c7)     14.3134 (1.05)     69.8645 (0.95)
--------------------------------------------------------------------------------------
Name (time in ms)                                         Mean                 OPS
--------------------------------------------------------------------------------------------
test_loads[orjson-citm_catalog.json] (0001_78f1379)     6.1344 (1.0)      163.0140 (1.0)
test_loads[orjson-citm_catalog.json] (0002_9f457c7)     6.4493 (1.05)     155.0566 (0.95)
--------------------------------------------------------------------------------------------
Name (time in us)                                     Mean            OPS (Kops/s)
--------------------------------------------------------------------------------------------
test_loads[orjson-github.json] (0001_78f1379)     238.4563 (1.01)           4.1936 (0.99)
test_loads[orjson-github.json] (0002_9f457c7)     235.2205 (1.0)            4.2513 (1.0)
--------------------------------------------------------------------------------------------
Name (time in ms)                                    Mean                 OPS
---------------------------------------------------------------------------------------
test_loads[orjson-twitter.json] (0001_78f1379)     3.2655 (1.15)     306.2292 (0.87)
test_loads[orjson-twitter.json] (0002_9f457c7)     2.8427 (1.0)      351.7743 (1.0)
---------------------------------------------------------------------------------------
```

Anyway, let me know what you think :)