### PR TITLE
Support arbitrary size integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ once_cell = { version = "1", default_features = false }
 pyo3-ffi = { version = "^0.16.4", default_features = false, features = ["extension-module"]}
 ryu = { version = "1", default_features = false }
 serde = { version = "1", default_features = false }
-serde_json = { version = "^1.0.68", default_features = false, features = ["std", "float_roundtrip"] }
+serde_json = { version = "^1.0.68", default_features = false, features = ["std", "float_roundtrip","raw_value","arbitrary_precision"] }
 simdutf8 = { version = "0.1", default_features = false, features = ["std"] }
 smallvec = { version = "^1.8", default_features = false, features = ["union", "write"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
     opt!(mptr, "OPT_SERIALIZE_UUID\0", opt::SERIALIZE_UUID);
     opt!(mptr, "OPT_SORT_KEYS\0", opt::SORT_KEYS);
     opt!(mptr, "OPT_STRICT_INTEGER\0", opt::STRICT_INTEGER);
+    opt!(mptr, "OPT_ARBITRARY_SIZE_INTEGER\0", opt::ARBITRARY_SIZE_INTEGER);
     opt!(mptr, "OPT_UTC_Z\0", opt::UTC_Z);
 
     typeref::init_typerefs();
@@ -168,7 +169,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
     };
 
     // maturin>=0.11.0 creates a python package that imports *, hiding dunder by default
-    let all: [&str; 20] = [
+    let all: [&str; 21] = [
         "__all__\0",
         "__version__\0",
         "dumps\0",
@@ -188,6 +189,7 @@ pub unsafe extern "C" fn PyInit_orjson() -> *mut PyObject {
         "OPT_SERIALIZE_UUID\0",
         "OPT_SORT_KEYS\0",
         "OPT_STRICT_INTEGER\0",
+        "OPT_ARBITRARY_SIZE_INTEGER\0",
         "OPT_UTC_Z\0",
     ];
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,6 +14,7 @@ pub const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub const APPEND_NEWLINE: Opt = 1 << 10;
 pub const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
+pub const ARBITRARY_SIZE_INTEGER: Opt = 1 << 12;
 
 // deprecated
 pub const SERIALIZE_DATACLASS: Opt = 0;
@@ -37,4 +38,5 @@ pub const MAX_OPT: i32 = (APPEND_NEWLINE
     | SERIALIZE_UUID
     | SORT_KEYS
     | STRICT_INTEGER
+    | ARBITRARY_SIZE_INTEGER
     | UTC_Z) as i32;

--- a/src/serialize/serializer.rs
+++ b/src/serialize/serializer.rs
@@ -187,7 +187,7 @@ impl<'p> Serialize for PyObjectSerializer {
                 if unlikely!(self.opts & STRICT_INTEGER != 0) {
                     Int53Serializer::new(self.ptr).serialize(serializer)
                 } else {
-                    IntSerializer::new(self.ptr).serialize(serializer)
+                    IntSerializer::new(self.ptr, self.opts & ARBITRARY_SIZE_INTEGER != 0).serialize(serializer)
                 }
             }
             ObType::None => serializer.serialize_unit(),

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -93,7 +93,7 @@ class ApiTests(unittest.TestCase):
         dumps() option out of range high
         """
         with self.assertRaises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=1 << 12)
+            orjson.dumps(True, option=1 << 13)
 
     def test_opts_multiple(self):
         """

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -1741,31 +1741,31 @@ class JSONTestSuiteParsingTests(unittest.TestCase):
         """
         i_number_huge_exp.json
         """
-        self._run_fail_json("i_number_huge_exp.json")
+        self._run_pass_json("i_number_huge_exp.json")
 
     def test_i_number_neg_int_huge_exp(self):
         """
         i_number_neg_int_huge_exp.json
         """
-        self._run_fail_json("i_number_neg_int_huge_exp.json")
+        self._run_pass_json("i_number_neg_int_huge_exp.json")
 
     def test_i_number_pos_double_huge_exp(self):
         """
         i_number_pos_double_huge_exp.json
         """
-        self._run_fail_json("i_number_pos_double_huge_exp.json")
+        self._run_pass_json("i_number_pos_double_huge_exp.json")
 
     def test_i_number_real_neg_overflow(self):
         """
         i_number_real_neg_overflow.json
         """
-        self._run_fail_json("i_number_real_neg_overflow.json")
+        self._run_pass_json("i_number_real_neg_overflow.json")
 
     def test_i_number_real_pos_overflow(self):
         """
         i_number_real_pos_overflow.json
         """
-        self._run_fail_json("i_number_real_pos_overflow.json")
+        self._run_pass_json("i_number_real_pos_overflow.json")
 
     def test_i_number_real_underflow(self):
         """

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -83,7 +83,7 @@ class JSONTestSuiteTransformTests(unittest.TestCase):
         """
         object_same_key_unclear_values.json
         """
-        self._pass_transform("object_same_key_unclear_values.json", b'{"a":-0.0}')
+        self._pass_transform("object_same_key_unclear_values.json", b'{"a":0}')
 
     def test_string_1_escaped_invalid_codepoint(self):
         """

--- a/test/test_type.py
+++ b/test/test_type.py
@@ -259,7 +259,32 @@ class TypeTests(unittest.TestCase):
         int 128-bit
         """
         for val in (18446744073709551616, -9223372036854775809):
-            self.assertRaises(orjson.JSONEncodeError, orjson.dumps, val)
+            with self.assertRaises(orjson.JSONEncodeError):
+                orjson.dumps(val), str(val).encode("utf-8")
+
+    def test_int_256(self):
+        """
+        int 256-bit
+        """
+        for val in (2**256 - 1, -(2**256 -1)):
+            with self.assertRaises(orjson.JSONEncodeError):
+                orjson.dumps(val), str(val).encode("utf-8")
+
+    def test_int_128_arbitrary_size(self):
+        """
+        int 128-bit
+        """
+        for val in (18446744073709551616, -9223372036854775809):
+            self.assertEqual(orjson.dumps(val, option=orjson.OPT_ARBITRARY_SIZE_INTEGER), str(val).encode("utf-8"))
+            self.assertEqual(orjson.loads(str(val)), val)
+
+    def test_int_256_arbitrary_size(self):
+        """
+        int 256-bit
+        """
+        for val in (2**256 - 1, -(2**256 -1)):
+            self.assertEqual(orjson.dumps(val, option=orjson.OPT_ARBITRARY_SIZE_INTEGER), str(val).encode("utf-8"))
+            self.assertEqual(orjson.loads(str(val)), val)
 
     def test_float(self):
         """


### PR DESCRIPTION
Hello, I am testing the waters here to see if this would be of interest to bringing in upstream. I would like this feature but I understand if sticking to 64-bit integers only is desired for some reason. The standard library supports arbitrary sized integers which is inline with the JSON spec so this would seem to be reasonable from that point of view.

This change adds support for arbitrarily large integers and arbitrary precision
floating point numbers.

serde_json has some support for this feature which makes it doable by
turning on a feature and doing a bit of trickery in the visitor. The
serializer path is more straightforward as you can use the repr of an
integer to get a string to pass directly to serde to use.

I don't think this will have a major impact on the performance in the
normal case as serde handles 64-bit values by going through a faster
path and not doing the string inside a map dance. That said, this will
have some impact on performance but I haven't measured it yet. Also,
this will serialize and deserialize some things that were previously
invalid.

I need to clean up some unwraps with proper error handling still but I wanted to get a sense if this might be of interest upstream before I go too far into cleaning it up.