### PR TITLE
Build musllinux packages for multiple platforms

### DIFF
--- a/.github/workflows/musllinux.yaml
+++ b/.github/workflows/musllinux.yaml
@@ -35,6 +35,7 @@ jobs:
         manylinux: musllinux_1_1
         args: --release --strip --out dist --no-sdist --cargo-extra-args="--features=unstable-simd" -i python${{ matrix.python.version }}
     - name: Set up QEMU
+      if: matrix.platform.arch != 'x86_64'
       uses: docker/setup-qemu-action@v2
       with:
         image: tonistiigi/binfmt:qemu-v6.2.0


### PR DESCRIPTION
Update the musllinux workflow to support building packages for multiple
platforms. Start with just aarch64 and x86_64 to start with.

Resolves #269 