### PR TITLE
Cross compile for manylinux2014 on aarch64

### DIFF
--- a/.github/workflows/linux-cross.yaml
+++ b/.github/workflows/linux-cross.yaml
@@ -17,7 +17,10 @@ jobs:
           { version: '3.9', abi: 'cp39-cp39' },
           { version: '3.10', abi: 'cp310-cp310' },
         ]
-        target: [armv7]
+        target: [
+          armv7,
+          aarch64,
+        ]
     steps:
     - uses: actions/checkout@v2
     - name: Build Wheels


### PR DESCRIPTION
https://github.com/ijl/orjson/issues/268#issuecomment-1200008274

This would restore wheels on Amazon Linux 2 / aarch64, used i.e. by AWS CodeBuild.