### PR TITLE
numpy.float16 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +109,16 @@ checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
  "packed_simd_2",
+]
+
+[[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+ "serde",
 ]
 
 [[package]]
@@ -161,6 +177,7 @@ dependencies = [
  "chrono",
  "compact_str",
  "encoding_rs",
+ "half",
  "itoa",
  "once_cell",
  "pyo3-build-config",
@@ -184,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "pyo3-build-config"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +255,20 @@ name = "serde"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -243,10 +292,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
+name = "syn"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ serde = { version = "1", default_features = false }
 serde_json = { path = "include/json", default_features = false, features = ["std", "float_roundtrip"] }
 simdutf8 = { version = "0.1", default_features = false, features = ["std"] }
 smallvec = { version = "^1.9", default_features = false, features = ["union", "write"] }
+half = { version = "2.1.0", default_features = false, features = ["serde"] }
 
 [build-dependencies]
 cc = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ JSONEncodeError: Integer exceeds 53-bit range
 ### numpy
 
 orjson natively serializes `numpy.ndarray` and individual `numpy.float64`,
-`numpy.float32`, `numpy.int64`, `numpy.int32`, `numpy.int16`, `numpy.int8`, `numpy.uint64`,
+`numpy.float32`, `numpy.float16`, `numpy.int64`, `numpy.int32`, `numpy.int16`, `numpy.int8`, `numpy.uint64`,
 `numpy.uint32`, `numpy.uint16`, `numpy.uint8`, `numpy.uintp`, or `numpy.intp`, and
 `numpy.datetime64` instances.
 

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -11,6 +11,7 @@ pub struct NumpyTypes {
     pub array: *mut PyTypeObject,
     pub float64: *mut PyTypeObject,
     pub float32: *mut PyTypeObject,
+    pub float16: *mut PyTypeObject,
     pub int64: *mut PyTypeObject,
     pub int32: *mut PyTypeObject,
     pub int16: *mut PyTypeObject,
@@ -215,6 +216,7 @@ unsafe fn load_numpy_types() -> Option<NumpyTypes> {
 
     let types = Some(NumpyTypes {
         array: look_up_numpy_type(numpy, "ndarray\0"),
+        float16: look_up_numpy_type(numpy, "float16\0"),
         float32: look_up_numpy_type(numpy, "float32\0"),
         float64: look_up_numpy_type(numpy, "float64\0"),
         int8: look_up_numpy_type(numpy, "int8\0"),

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -107,6 +107,15 @@ class TestNumpy:
             == b"[0,4294967295]"
         )
 
+    def test_numpy_array_d1_f16(self):
+        assert (
+            orjson.dumps(
+                numpy.array([65504, 5.9604645e-8], numpy.float16),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            )
+            == b"[65504.0,5.9604645e-8]"
+        )
+
     def test_numpy_array_d1_f32(self):
         assert (
             orjson.dumps(
@@ -376,15 +385,6 @@ class TestNumpy:
                 == "numpy array is not C contiguous; use ndarray.tolist() in default"
             )
 
-    def test_numpy_array_unsupported_dtype(self):
-        array = numpy.array([[1, 2], [3, 4]], numpy.float16)
-        with pytest.raises(orjson.JSONEncodeError) as cm:
-            orjson.dumps(array, option=orjson.OPT_SERIALIZE_NUMPY)
-        assert "unsupported datatype in numpy array" in str(cm)
-        assert orjson.dumps(
-            array, default=numpy_default, option=orjson.OPT_SERIALIZE_NUMPY
-        ) == orjson.dumps(array.tolist())
-
     def test_numpy_array_d1(self):
         array = numpy.array([1])
         assert (
@@ -603,6 +603,12 @@ class TestNumpy:
                 numpy.uint64(18446744073709551615), option=orjson.OPT_SERIALIZE_NUMPY
             )
             == b"18446744073709551615"
+        )
+
+    def test_numpy_scalar_float16(self):
+        assert (
+            orjson.dumps(numpy.half(1.0), option=orjson.OPT_SERIALIZE_NUMPY)
+            == b"1.0"
         )
 
     def test_numpy_scalar_float32(self):


### PR DESCRIPTION
Added support for float16. Appreciate any remarks. 
Tried to use just `f16.serialize` but I'm getting strange results(), so I used convert to f32 here. At least, this approach works.
https://github.com/starkat99/half-rs/issues/60