### PR TITLE
pyproject.toml don't restrict upper maturin version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=0.13"]
 
 [tool.maturin]
 sdist-include = ["build.rs", "Cargo.lock", "include/**/*"]


### PR DESCRIPTION
The just released maturin 0.14.0 appears to work fine with orjson, lets remove this restriction for now as it doesn't seem to be needed.