### PR TITLE
Update musl linux build to inlcude Python 3.11

### DIFF
--- a/.github/workflows/musllinux.yaml
+++ b/.github/workflows/musllinux.yaml
@@ -16,6 +16,7 @@ jobs:
           { version: '3.8' },
           { version: '3.9' },
           { version: '3.10' },
+          { version: '3.11' },
         ]
         platform:
           - target: aarch64-unknown-linux-musl


### PR DESCRIPTION
Was there a specific reason from excluding python 3.11 from the musl linux wheels?
If so, feel free to close this pull request. 

