### PR TITLE
add armv6 target

### DIFF
--- a/.github/workflows/linux-cross.yaml
+++ b/.github/workflows/linux-cross.yaml
@@ -19,6 +19,7 @@ jobs:
           { version: '3.11', abi: 'cp311-cp311' },
         ]
         target: [
+          armv6,
           armv7,
           aarch64,
         ]


### PR DESCRIPTION
Hi, I'm currently trying to install Home-Assistant Core on a Raspberry Pi Zero WH (armv6) and stumbled upon an inconvenience that could be (hopefully) solved via the GH Action: since HA dropped support for the Zero with the HAOS the only way to install it is [via pip](https://www.home-assistant.io/installation/raspberrypi#install-home-assistant-core). According to this [community comment](https://community.home-assistant.io/t/time-to-upgrade-the-installation-instructions-for-core-on-raspberry-pi/485749/3) the installation on a Zero is possible but takes up to 15 hours (when rust and maturin are already installed as dependency before installing HA). I can confirm that the `Collecting orjson==3.8.1 Downloading... Installing build dependencies...` takes more than 4 hours (`htop` showed a `rustc` process that uses 100% CPU, but I did cancel it manually and am currently trying to install it a second time). 

I'm not familiar with building pip packages and would need guidance on how to test locally on some emulated docker image¿ if needed (since building it on the Zero seems out of question with the >10h build time; I'm not sure yet if any other dependency takes some hours to build too and orjson "only" requires about 5h).

Looking on the `linux-cross` GHA the `matrix.target` is used by `uraimo/run-on-arch-action` which supports `armv6` and [`messense/maturin-action`](https://github.com/PyO3/maturin-action) but I'm not sure if `Cargo ... --target armv6 ...` is going to work (I'm not familiar with rust as well and I don't know if [this](https://github.com/japaric/rust-cross/issues/42) is related?).

It would be very helpful if this simple `armv6` addition could be provided if everything works out-of-box via GHA without changing anything. If it's not working you can close this PR and I hope everything works after 15h and I don't have to update this debug setup anytime soon.

---

Some additional infos: Similar to the HA community post I intend to use my spare Zeros for some HA debugging and testing as all my Pi3 and Pi4 are occupied; I don't intend it to run a full-blown smarthome on it.

Steps to reproduce the 15h build:
(maybe?) Build the repo on a Raspberry Zero.

(or using my way) Install HA:
1. flash Raspberry OS lite 32bit on a Pi Zero
2. install dependencies as described in the HA installation guide
3. skip all those "security" steps that requires to add a new user and setup the venv as not needed in this test case
4. install rust `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
5. install maturin? `pip install maturin`
6. install HA `pip install homeassistant==2022.12.8`

Without installing rust (and maybe maturin) first the command `pip install homeassistant` (without providing a version) installed version 2022.6.4 in my case (as some newer python wheels failed, so I guess it falls back to the newest it is able to install?).