### PR TITLE
feat(opt): add OPT_DATETIME_MILLISECONDS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,11 @@ pub unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
     opt!(mptr, "OPT_SORT_KEYS\0", opt::SORT_KEYS);
     opt!(mptr, "OPT_STRICT_INTEGER\0", opt::STRICT_INTEGER);
     opt!(mptr, "OPT_UTC_Z\0", opt::UTC_Z);
+    opt!(
+        mptr,
+        "OPT_DATETIME_MILLISECONDS\0",
+        opt::DATETIME_MILLISECONDS
+    );
 
     add!(mptr, "JSONDecodeError\0", typeref::JsonDecodeError);
     add!(mptr, "JSONEncodeError\0", typeref::JsonEncodeError);

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,6 +14,7 @@ pub const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub const APPEND_NEWLINE: Opt = 1 << 10;
 pub const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
+pub const DATETIME_MILLISECONDS: Opt = 1 << 12;
 
 // deprecated
 pub const SERIALIZE_DATACLASS: Opt = 0;
@@ -37,4 +38,5 @@ pub const MAX_OPT: i32 = (APPEND_NEWLINE
     | SERIALIZE_UUID
     | SORT_KEYS
     | STRICT_INTEGER
-    | UTC_Z) as i32;
+    | UTC_Z
+    | DATETIME_MILLISECONDS) as i32;

--- a/src/serialize/datetime.rs
+++ b/src/serialize/datetime.rs
@@ -4,29 +4,8 @@ use crate::opt::*;
 use crate::serialize::datetimelike::{DateTimeBuffer, DateTimeError, DateTimeLike, Offset};
 use crate::serialize::error::*;
 use crate::typeref::*;
+use crate::{write_double_digit, write_microsecond, write_triple_digit};
 use serde::ser::{Serialize, Serializer};
-
-macro_rules! write_double_digit {
-    ($buf:ident, $value:ident) => {
-        if $value < 10 {
-            $buf.push(b'0');
-        }
-        $buf.extend_from_slice(itoa::Buffer::new().format($value).as_bytes());
-    };
-}
-
-macro_rules! write_microsecond {
-    ($buf:ident, $microsecond:ident) => {
-        if $microsecond != 0 {
-            let mut buf = itoa::Buffer::new();
-            let formatted = buf.format($microsecond);
-            $buf.extend_from_slice(
-                &[b'.', b'0', b'0', b'0', b'0', b'0', b'0'][..(7 - formatted.len())],
-            );
-            $buf.extend_from_slice(formatted.as_bytes());
-        }
-    };
-}
 
 #[repr(transparent)]
 pub struct Date {
@@ -100,10 +79,10 @@ impl Time {
         buf.push(b':');
         let second = ffi!(PyDateTime_TIME_GET_SECOND(self.ptr)) as u8;
         write_double_digit!(buf, second);
-        if self.opts & OMIT_MICROSECONDS == 0 {
-            let microsecond = ffi!(PyDateTime_TIME_GET_MICROSECOND(self.ptr)) as u32;
-            write_microsecond!(buf, microsecond);
-        }
+
+        let microsecond = ffi!(PyDateTime_TIME_GET_MICROSECOND(self.ptr)) as u32;
+        write_microsecond!(self.opts, buf, microsecond);
+
         Ok(())
     }
 }

--- a/src/serialize/datetimelike.rs
+++ b/src/serialize/datetimelike.rs
@@ -32,6 +32,7 @@ impl DateTimeBuffer {
     }
 }
 
+#[macro_export]
 macro_rules! write_double_digit {
     ($buf:ident, $value:expr) => {
         if $value < 10 {
@@ -41,6 +42,7 @@ macro_rules! write_double_digit {
     };
 }
 
+#[macro_export]
 macro_rules! write_triple_digit {
     ($buf:ident, $value:expr) => {
         if $value < 100 {
@@ -50,6 +52,23 @@ macro_rules! write_triple_digit {
             $buf.push(b'0');
         }
         $buf.extend_from_slice(itoa::Buffer::new().format($value).as_bytes());
+    };
+}
+
+#[macro_export]
+macro_rules! write_microsecond {
+    ($opts:expr, $buf:ident, $microsecond:ident) => {
+        if $microsecond != 0 {
+            if $opts & DATETIME_MILLISECONDS != 0
+                || $opts & (OMIT_MICROSECONDS | DATETIME_MILLISECONDS) == 0
+            {
+                $buf.push(b'.');
+                write_triple_digit!($buf, $microsecond / 1_000);
+            }
+            if $opts & OMIT_MICROSECONDS == 0 {
+                write_triple_digit!($buf, $microsecond % 1_000);
+            }
+        }
     };
 }
 
@@ -115,22 +134,10 @@ pub trait DateTimeLike {
         write_double_digit!(buf, self.minute());
         buf.push(b':');
         write_double_digit!(buf, self.second());
-        if opts & OMIT_MICROSECONDS == 0 {
-            let microsecond = self.microsecond();
-            if microsecond != 0 {
-                buf.push(b'.');
-                write_triple_digit!(buf, microsecond / 1_000);
-                write_triple_digit!(buf, microsecond % 1_000);
-                // Don't support writing nanoseconds for now.
-                // If requested, something like the following should work,
-                // and the `DateTimeBuffer` type alias should be changed to
-                // have length 35.
-                // let nanosecond = self.nanosecond();
-                // if nanosecond % 1_000 != 0 {
-                //     write_triple_digit!(buf, nanosecond % 1_000);
-                // }
-            }
-        }
+
+        let microsecond = self.microsecond();
+        write_microsecond!(opts, buf, microsecond);
+
         if self.has_tz() || opts & NAIVE_UTC != 0 {
             let offset = self.offset()?;
             let mut offset_second = offset.second;

--- a/src/serialize/datetimelike.rs
+++ b/src/serialize/datetimelike.rs
@@ -58,16 +58,20 @@ macro_rules! write_triple_digit {
 #[macro_export]
 macro_rules! write_microsecond {
     ($opts:expr, $buf:ident, $microsecond:ident) => {
-        if $microsecond != 0 {
-            if $opts & DATETIME_MILLISECONDS != 0
-                || $opts & (OMIT_MICROSECONDS | DATETIME_MILLISECONDS) == 0
-            {
-                $buf.push(b'.');
-                write_triple_digit!($buf, $microsecond / 1_000);
-            }
-            if $opts & OMIT_MICROSECONDS == 0 {
-                write_triple_digit!($buf, $microsecond % 1_000);
-            }
+        let millisecond = $microsecond / 1_000;
+        let microsecond = $microsecond % 1_000;
+        let write_microseconds = $opts & OMIT_MICROSECONDS == 0
+            && $opts & DATETIME_MILLISECONDS == 0
+            && microsecond != 0;
+        let write_milliseconds = $opts & DATETIME_MILLISECONDS != 0 && millisecond != 0;
+
+        if write_milliseconds || write_microseconds {
+            $buf.push(b'.');
+            write_triple_digit!($buf, millisecond);
+        }
+
+        if write_microseconds {
+            write_triple_digit!($buf, microsecond);
         }
     };
 }

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -580,10 +580,22 @@ class TestDatetime:
         """
         assert (
                 orjson.dumps(
-                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123)],
+                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123456)],
                     option=orjson.OPT_DATETIME_MILLISECONDS,
                 )
-                == b'["2000-01-01T02:03:04.000123"]'
+                == b'["2000-01-01T02:03:04.123"]'
+        )
+
+    def test_datetime_milliseconds_zero(self):
+        """
+        datetime.datetime OPT_DATETIME_MILLISECONDS
+        """
+        assert (
+                orjson.dumps(
+                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 456)],
+                    option=orjson.OPT_DATETIME_MILLISECONDS,
+                )
+                == b'["2000-01-01T02:03:04"]'
         )
 
     def test_datetime_milliseconds_omit_microseconds(self):
@@ -592,11 +604,11 @@ class TestDatetime:
         """
         assert (
                 orjson.dumps(
-                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123)],
+                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123456)],
                     option=orjson.OPT_OMIT_MICROSECONDS
                     | orjson.OPT_DATETIME_MILLISECONDS,
                 )
-                == b'["2000-01-01T02:03:04.000"]'
+                == b'["2000-01-01T02:03:04.123"]'
         )
 
     def test_datetime_omit_microseconds_naive(self):

--- a/test/test_datetime.py
+++ b/test/test_datetime.py
@@ -574,6 +574,31 @@ class TestDatetime:
             == b'["2000-01-01T02:03:04"]'
         )
 
+    def test_datetime_milliseconds(self):
+        """
+        datetime.datetime OPT_DATETIME_MILLISECONDS
+        """
+        assert (
+                orjson.dumps(
+                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123)],
+                    option=orjson.OPT_DATETIME_MILLISECONDS,
+                )
+                == b'["2000-01-01T02:03:04.000123"]'
+        )
+
+    def test_datetime_milliseconds_omit_microseconds(self):
+        """
+        datetime.datetime OPT_DATETIME_MILLISECONDS
+        """
+        assert (
+                orjson.dumps(
+                    [datetime.datetime(2000, 1, 1, 2, 3, 4, 123)],
+                    option=orjson.OPT_OMIT_MICROSECONDS
+                    | orjson.OPT_DATETIME_MILLISECONDS,
+                )
+                == b'["2000-01-01T02:03:04.000"]'
+        )
+
     def test_datetime_omit_microseconds_naive(self):
         """
         datetime.datetime naive OPT_OMIT_MICROSECONDS


### PR DESCRIPTION
This PR adds the option `OPT_DATETIME_MILLISECONDS` for users that need `time` and `datetime` objects serialized with millisecond precision.

The combinations of `OPT_DATETIME_MILLISECONDS` and `OPT_OMIT_MICROSECONDS` are as follows:

Neither is set: 0.123456 (microsecond precision)
`OPT_DATETIME_MILLISECONDS` is set: 0.123 (millisecond precision)
`OPT_OMIT_MICROSECONDS` is set: 0
Both are set: 0.123 (millisecond precision)
The default behaviour of the library was left unchanged.

Closes https://github.com/ijl/orjson/issues/333.

P. S.: I apologize for creating a new PR for this, branches in my fork got a bit messed up.