### PR TITLE
Build ppc64le wheels

### DIFF
--- a/.github/workflows/linux-cross.yaml
+++ b/.github/workflows/linux-cross.yaml
@@ -16,6 +16,7 @@ jobs:
         target: [
           { arch: 'armv7', flags: '--features=yyjson -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort' },
           { arch: 'aarch64', flags: '--features=yyjson' },  # build-std: aarch64-linux-gnu.so: undefined symbol: __aarch64_swp4_rel, likely QEMU?
+          { arch: 'ppc64le', flags: '--features=yyjson' },
         ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/musllinux.yaml
+++ b/.github/workflows/musllinux.yaml
@@ -15,6 +15,8 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-musl
             arch: aarch64
+          - target: powerpc64le-unknown-linux-musl
+            arch: ppc64le
           - target: x86_64-unknown-linux-musl
             arch: x86_64
     steps:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ support for 64-bit
 file-like objects
 
 orjson supports CPython 3.7, 3.8, 3.9, 3.10, and 3.11. It distributes x86_64/amd64,
-aarch64/armv8, and arm7 wheels for Linux, amd64 and aarch64 wheels for macOS,
+aarch64/armv8, arm7 and ppc64le wheels for Linux, amd64 and aarch64 wheels for macOS,
 and amd64 wheels for Windows. orjson does not support PyPy. Releases
 follow semantic versioning and serializing a new object type
 without an opt-in flag is considered a breaking change.


### PR DESCRIPTION
Minor patch that will enable ppc64le wheels. 
This is no change content-wise, it'll just enable another CPU architecture.