### PR TITLE
Py_DECREF for owned traceback and type objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,10 @@ fn raise_dumps_exception_dynamic(err: &String) -> *mut PyObject {
 
         if !cause_tp.is_null() {
             PyException_SetCause(val, cause_val);
+            Py_DECREF(cause_tp);
+        }
+        if !cause_traceback.is_null() {
+            Py_DECREF(cause_traceback);
         }
 
         PyErr_Restore(tp, val, traceback);

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 import uuid
 
 import pytest
@@ -260,3 +261,17 @@ class TestType:
 
         with pytest.raises(orjson.JSONEncodeError):
             orjson.dumps(ref, default=default)
+
+    def test_reference_cleanup_default(self):
+        """
+        references to encoded objects are cleaned up
+        """
+        ref = Custom()
+
+        def default(obj):
+            raise TypeError
+
+        with pytest.raises(orjson.JSONEncodeError):
+            orjson.dumps(ref, default=default)
+
+        assert sys.getrefcount(ref) == 2 # one for ref, one for default


### PR DESCRIPTION
See #392 for context.

The exception handling for a serialization error owns references to the cause type and traceback, but did not decrement ref counts on exit.