### PR TITLE
Use PyType_GetDict to safely access tp_dict [3.12]

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -125,7 +125,20 @@ macro_rules! str_hash {
     };
 }
 
-#[cfg(Py_3_10)]
+#[cfg(Py_3_12)]
+macro_rules! pydict_contains {
+    ($obj1:expr, $obj2:expr) => {
+        unsafe {
+            pyo3_ffi::_PyDict_Contains_KnownHash(
+                pyo3_ffi::PyType_GetDict($obj1),
+                $obj2,
+                (*$obj2.cast::<pyo3_ffi::PyASCIIObject>()).hash,
+            ) == 1
+        }
+    };
+}
+
+#[cfg(all(Py_3_10, not(Py_3_12)))]
 macro_rules! pydict_contains {
     ($obj1:expr, $obj2:expr) => {
         unsafe {

--- a/test/test_default.py
+++ b/test/test_default.py
@@ -275,3 +275,15 @@ class TestType:
             orjson.dumps(ref, default=default)
 
         assert sys.getrefcount(ref) == 2  # one for ref, one for default
+
+    def test_default_set(self):
+        """
+        dumps() default function with set
+        """
+
+        def default(obj):
+            if isinstance(obj, set):
+                return list(obj)
+            raise TypeError
+
+        assert orjson.dumps({1, 2}, default=default) == b"[1,2]"


### PR DESCRIPTION
This resolve the `Segmenation fault` issues with Python `3.12.0b1` - `3.12.0b4`. My particular test case, although others in the existing test suite failed as well (when tested with Python 3.12.0b4).
```py
import orjson

def default(obj):
    if isinstance(obj, set):
        return list(obj)
    raise TypeError

print(orjson.dumps({1, 2}, default=default))
```

For `3.12` it's no longer safe to assume `tp_dict` is always a `PyObject` as it can be `NULL` too for static builtin types now. Instead use `PyType_GetDict` (new in `3.12`) to access it safely. 

Requires: https://github.com/PyO3/pyo3/pull/3339

Refs:
https://docs.python.org/3.12/whatsnew/changelog.html?highlight=pytype_getdict#c-api
https://docs.python.org/3.12/c-api/type.html#c.PyType_GetDict
https://docs.python.org/3.12/c-api/typeobj.html#c.PyTypeObject.tp_dict

https://github.com/python/cpython/pull/103912