### PR TITLE
Expose UTF-8 as an `orjson.ENCODING` attribute

### DIFF
--- a/pysrc/orjson/__init__.py
+++ b/pysrc/orjson/__init__.py
@@ -3,9 +3,12 @@
 from .orjson import *
 from .orjson import __version__
 
+ENCODING = 'utf-8'
+
 __all__ = (
     "__version__",
     "dumps",
+    "ENCODING",
     "Fragment",
     "JSONDecodeError",
     "JSONEncodeError",


### PR DESCRIPTION
A convenience, to allow people to do things like `orjson.dumps(obj).decode(orjson.ENCODING)` and similar.