### PR TITLE
Use a faster, safe implementation of `is_four_byte`

### DIFF
--- a/src/str/check.rs
+++ b/src/str/check.rs
@@ -4,29 +4,20 @@ const STRIDE_SIZE: usize = 8;
 
 pub fn is_four_byte(buf: &str) -> bool {
     let as_bytes = buf.as_bytes();
-    let len = as_bytes.len();
-    unsafe {
-        let mut idx = 0;
-        while idx < len.saturating_sub(STRIDE_SIZE) {
-            let mut val: bool = false;
-            val |= *as_bytes.get_unchecked(idx) > 239;
-            val |= *as_bytes.get_unchecked(idx + 1) > 239;
-            val |= *as_bytes.get_unchecked(idx + 2) > 239;
-            val |= *as_bytes.get_unchecked(idx + 3) > 239;
-            val |= *as_bytes.get_unchecked(idx + 4) > 239;
-            val |= *as_bytes.get_unchecked(idx + 5) > 239;
-            val |= *as_bytes.get_unchecked(idx + 6) > 239;
-            val |= *as_bytes.get_unchecked(idx + 7) > 239;
-            idx += STRIDE_SIZE;
-            if val {
-                return true;
-            }
+    let chunks = as_bytes.chunks_exact(STRIDE_SIZE);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+        let mut val = false;
+        for &b in chunk {
+            val |= b > 239;
         }
-        let mut ret = false;
-        while idx < len {
-            ret |= *as_bytes.get_unchecked(idx) > 239;
-            idx += 1;
+        if val {
+            return true;
         }
-        ret
     }
+    let mut val = false;
+    for &b in remainder {
+        val |= b > 239;
+    }
+    val
 }


### PR DESCRIPTION
In my benchmarking, this is actually a fair bit faster, and it will automatically adjust to changes in the `STRIDE_SIZE`, which it might be better to bump to 16 to match basic simd size, benchmarking shows this would be even faster, at least on an m1 pro