### PR TITLE
Change ahash dep. back to SemVer and update to 0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "const-random",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ no-panic = [
 yyjson = []
 
 [dependencies]
-ahash = { version = "=0.8.6", default_features = false, features = ["compile-time-rng"] }
+ahash = { version = "^0.8.6", default_features = false, features = ["compile-time-rng"] }
 arrayvec = { version = "0.7", default_features = false, features = ["std", "serde"] }
 associative-cache = { version = "2", default_features = false }
 beef = { version = "0.5", default_features = false, features = ["impl_serde"] }


### PR DESCRIPTION
It looks like `ahash` was pinned to 0.8.6 in https://github.com/ijl/orjson/commit/ef675bfd610bbd2692e809e591ce4f956aef5579, but I don’t see any comment about why that was required.

If we’re going to pin a version, could it please be the current one? The tests pass for me.