### PR TITLE
Fix buffer overread in format_escaped_str, again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ dependencies = [
  "itoa",
  "itoap",
  "once_cell",
- "page_size",
  "pyo3-build-config",
  "pyo3-ffi",
  "ryu",
@@ -216,16 +215,6 @@ dependencies = [
  "simdutf8",
  "smallvec",
  "version_check",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -373,28 +362,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ encoding_rs = { version = "0.8", default_features = false }
 itoa = { version = "1", default_features = false }
 itoap = { version = "1", features = ["std", "simd"] }
 once_cell = { version = "1", default_features = false, features = ["race"] }
-page_size = { version = "0.6" }
 pyo3-ffi = { version = "^0.20.2", default_features = false, features = ["extension-module"]}
 ryu = { version = "1", default_features = false }
 serde = { version = "1", default_features = false }

--- a/src/serialize/writer/simd.rs
+++ b/src/serialize/writer/simd.rs
@@ -2,7 +2,6 @@
 // Copyright 2023-2024 liuq19, ijl
 // adapted from sonic-rs' src/util/string.rs
 
-use crate::typeref::PAGE_SIZE;
 use core::simd::cmp::{SimdPartialEq, SimdPartialOrd};
 
 macro_rules! impl_escape_unchecked {
@@ -64,13 +63,8 @@ macro_rules! impl_format_simd {
                 }
             }
 
-            let mut v = if unlikely!(is_cross_page!(sptr)) {
-                let mut v = StrVector::default();
-                v.as_mut_array()[..nb].copy_from_slice(core::slice::from_raw_parts(sptr, nb));
-                v
-            } else {
-                StrVector::from_slice(core::slice::from_raw_parts(sptr, STRIDE))
-            };
+            let mut v = StrVector::default();
+            v.as_mut_array()[..nb].copy_from_slice(core::slice::from_raw_parts(sptr, nb));
             while nb > 0 {
                 v.copy_to_slice(core::slice::from_raw_parts_mut(dptr, STRIDE));
                 let mut mask = (v.simd_eq(blash) | v.simd_eq(quote) | v.simd_lt(x20)).to_bitmask()
@@ -97,12 +91,6 @@ macro_rules! impl_format_simd {
         }
 
         return dptr as usize - dstart as usize;
-    };
-}
-
-macro_rules! is_cross_page {
-    ($src:expr) => {
-        unsafe { (($src as usize & (PAGE_SIZE - 1)) + STRIDE) > PAGE_SIZE }
     };
 }
 

--- a/src/typeref.rs
+++ b/src/typeref.rs
@@ -75,9 +75,6 @@ pub static mut DESCR_STR: *mut PyObject = null_mut();
 pub static mut VALUE_STR: *mut PyObject = null_mut();
 pub static mut INT_ATTR_STR: *mut PyObject = null_mut();
 
-#[cfg(feature = "unstable-simd")]
-pub static mut PAGE_SIZE: usize = 0;
-
 #[cfg(feature = "yyjson")]
 pub const YYJSON_BUFFER_SIZE: usize = 1024 * 1024 * 8;
 
@@ -139,10 +136,6 @@ fn _init_typerefs_impl() -> bool {
     unsafe {
         debug_assert!(crate::opt::MAX_OPT < u16::MAX as i32);
 
-        #[cfg(feature = "unstable-simd")]
-        {
-            PAGE_SIZE = page_size::get();
-        }
         assert!(crate::deserialize::KEY_MAP
             .set(crate::deserialize::KeyMap::default())
             .is_ok());


### PR DESCRIPTION
Commit 528220fb0d18bbf0212de7f0ce5c7aec209bc6e7 restored the buffer overread that I removed in commit 29884e617d35c6774f60b8fedf6de47d74edcd2f (#455). A buffer overread that doesn’t cross a page boundary is still undefined behavior, even if it doesn’t happen to cause an immediate segfault, and all undefined behavior must be avoided.

(Reopened from #457.)