### PR TITLE
Build wheels for python 3.13

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -62,6 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
+          { version: '3.13' },
           { version: '3.12' },
           { version: '3.11' },
           { version: '3.10' },
@@ -136,6 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
+          { version: '3.13' },
           { version: '3.12' },
           { version: '3.11' },
           { version: '3.10' },
@@ -209,6 +211,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
+          { version: '3.13', abi: 'cp313-cp313' },
           { version: '3.12', abi: 'cp312-cp312' },
           { version: '3.11', abi: 'cp311-cp311' },
           { version: '3.10', abi: 'cp310-cp310' },
@@ -295,6 +298,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
+          { version: '3.13', macosx_target: "10.15" },
           { version: '3.12', macosx_target: "10.15" },
           { version: '3.11', macosx_target: "10.15" },
           { version: '3.10', macosx_target: "10.15" },

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ support for 64-bit
 * does not provide `load()` or `dump()` functions for reading from/writing to
 file-like objects
 
-orjson supports CPython 3.8, 3.9, 3.10, 3.11, and 3.12. It distributes
+orjson supports CPython 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13. It distributes
 amd64/x86_64, aarch64/armv8, POWER/ppc64le, and s390x wheels for Linux,
 amd64 and aarch64 wheels for macOS, and amd64 and i686/x86 wheels for Windows.
 orjson does not and will not support PyPy. orjson does not and will not


### PR DESCRIPTION
PyO3 now supports 3.13 thanks to https://github.com/PyO3/pyo3/pull/4184, so wheels for 3.13 can be build too.

A release with the feature has not been released yet, but this PR is open to support it once it has

Closes #494