### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -276,7 +276,7 @@ class TestApi:
         a = "a" * 900
         b = "b" * 4096
         c = "c" * 4096 * 4096
-        assert orjson.dumps([a, b, c]) == f'["{a}","{b}","{c}"]'.encode("utf-8")
+        assert orjson.dumps([a, b, c]) == f'["{a}","{b}","{c}"]'.encode()
 
     def test_bytes_null_terminated(self):
         """

--- a/test/test_fragment.py
+++ b/test/test_fragment.py
@@ -49,7 +49,7 @@ class TestFragment:
     def test_fragment_fragment_str_array(self):
         n = 8096
         obj = [orjson.Fragment('"🐈"')] * n
-        ref = b"[" + b",".join((b'"\xf0\x9f\x90\x88"' for _ in range(0, n))) + b"]"
+        ref = b"[" + b",".join(b'"\xf0\x9f\x90\x88"' for _ in range(0, n)) + b"]"
         assert orjson.dumps(obj) == ref
 
     def test_fragment_fragment_str_invalid(self):

--- a/test/test_uuid.py
+++ b/test/test_uuid.py
@@ -99,4 +99,4 @@ class TestUUID:
             uuid.uuid5(uuid.NAMESPACE_DNS, "python.org"),
         )
         for val in uuids:
-            assert orjson.dumps(val) == f'"{val}"'.encode("utf-8")
+            assert orjson.dumps(val) == f'"{val}"'.encode()


### PR DESCRIPTION
Filter all code over `pyupgrade --py38-plus`.