### PR TITLE
Update yyjson.c

### DIFF
--- a/include/yyjson/yyjson.c
+++ b/include/yyjson/yyjson.c
@@ -5265,7 +5265,7 @@ static_inline bool read_string(u8 **ptr,
     
     u8 *cur = *ptr;
     u8 **end = ptr;
-    u8 *src = ++cur, *dst, *pos;
+    u8 *src = ++cur, *dst;
     u16 hi, lo;
     u32 uni, tmp;
     


### PR DESCRIPTION
Fix the variable ‘pos’ set but not used [-Wunused-but-set-variable] warning to allow compiling.

-----

The following warnings were emitted during compilation:
warning: orjson@3.10.12: include/yyjson/yyjson.c: In function ‘read_string’:
warning: orjson@3.10.12: include/yyjson/yyjson.c:5268:29: warning: variable ‘pos’ set but not used [-Wunused-but-set-variable]
warning: orjson@3.10.12:  5268 |     u8 *src = ++cur, *dst, *pos;
warning: orjson@3.10.12:       |                             ^~~

error: could not compile `orjson` (lib) due to 1 previous error