### PR TITLE
Remove arrow from test requirements

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,3 @@
-arrow
 faker
 numpy;(platform_machine=="x86_64" or (platform_machine=="aarch64" and sys_platform == "linux")) and python_version<"3.13"
 pendulum;sys_platform=="linux" and platform_machine=="x86_64" and python_version<"3.12"


### PR DESCRIPTION
None of the tests actually uses it.

Fixes #559.