### PR TITLE
Remove 'links = python' from pyo3-ffi

### DIFF
--- a/include/pyo3/pyo3-ffi/Cargo.toml
+++ b/include/pyo3/pyo3-ffi/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/pyo3/pyo3"
 categories = ["api-bindings", "development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-links = "python"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
If one were to depend on both `orjson` as a Rust library and `pyo3` in their `Cargo.toml` via:
```
[dependencies]
pyo3 = "0.25"
orjson = { git = "https://github.com/ijl/orjson.git", rev = "4b29943c2df5035f7ec573c1a0052c08d293c119"  }
```

then `cargo build` would throw the following error:
```
error: failed to select a version for `pyo3-ffi`.
    ... required by package `pyo3 v0.25.0`
    ... which satisfies dependency `pyo3 = "^0.25"` (locked to 0.25.0) of package `orjson_test v0.1.0 (/home/diliopoulos/projects/software/orjson_test)`
versions that meet the requirements `=0.25.0` (locked to 0.25.0) are: 0.25.0

the package `pyo3-ffi` links to the native library `python`, but it conflicts with a previous package which links to `python` as well:
package `pyo3-ffi v0.23.3 (https://github.com/ijl/orjson.git?rev=4b29943c2df5035f7ec573c1a0052c08d293c119#4b29943c)`
    ... which satisfies git dependency `pyo3-ffi` of package `orjson v3.10.18 (https://github.com/ijl/orjson.git?rev=4b29943c2df5035f7ec573c1a0052c08d293c119#4b29943c)`
    ... which satisfies git dependency `orjson` of package `orjson_test v0.1.0 (/home/diliopoulos/projects/software/orjson_test)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "python"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `pyo3-ffi` which could resolve this conflict
```
The `links = "python"` was introduced in pyo3 via https://github.com/PyO3/pyo3/pull/1819 and I think its intended use was for some weird packaging/building issues with PyOxidizer. The unintended side-effect though here is that this configuration also does not support the use case I mentioned above. I think overall this should be safe enough since there is only one active `libpython` binary at any given moment and both `pyo3` and `orjson` would end up linking to the same such binary regardless.  