### PR TITLE
feat: add `OPT_ENSURE_ASCII` functionality, with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ Users with `dict` objects using non-`str` keys should specify `option=orjson.OPT
 `indent` is replaced by `option=orjson.OPT_INDENT_2` and other levels of indentation are not
 supported.
 
-`ensure_ascii` is probably not relevant today and UTF-8 characters cannot be
-escaped to ASCII.
+`ensure_ascii` is replaced by `option=orjson.OPT_ENSURE_ASCII`.
 
 ### Serialize
 
@@ -247,6 +246,23 @@ pattern copies the original contents.
 b"[]"
 >>> orjson.dumps([], option=orjson.OPT_APPEND_NEWLINE)
 b"[]\n"
+```
+
+##### OPT_ENSURE_ASCII
+
+Escape all incoming non-ASCII characters in strings to ASCII equivalent.
+
+Per the JSON specification, decoding this serialization variant still
+results in the original input value, as expected.
+
+```python
+>>> import orjson
+>>> orjson.dumps({"你_好": "🍉"})
+b'{"\xe4\xbd\xa0_\xe5\xa5\xbd":"\xf0\x9f\x8d\x89"}'
+>>> orjson.dumps({"你_好": "🍉"}, option=orjson.OPT_ENSURE_ASCII)
+b'{"\\u4f60_\\u597d":"\\ud83c\\udf49"}'
+>>> orjson.loads(b'{"\\u4f60_\\u597d":"\\ud83c\\udf49"}')
+{'你_好': '🍉'}
 ```
 
 ##### OPT_INDENT_2

--- a/pysrc/orjson/__init__.py
+++ b/pysrc/orjson/__init__.py
@@ -11,6 +11,7 @@ __all__ = (
     "JSONEncodeError",
     "loads",
     "OPT_APPEND_NEWLINE",
+    "OPT_ENSURE_ASCII",
     "OPT_INDENT_2",
     "OPT_NAIVE_UTC",
     "OPT_NON_STR_KEYS",

--- a/pysrc/orjson/__init__.pyi
+++ b/pysrc/orjson/__init__.pyi
@@ -17,6 +17,7 @@ class Fragment(tuple):
     contents: Union[bytes, str]
 
 OPT_APPEND_NEWLINE: int
+OPT_ENSURE_ASCII: int
 OPT_INDENT_2: int
 OPT_NAIVE_UTC: int
 OPT_NON_STR_KEYS: int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ pub(crate) unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
         add!(mptr, c"Fragment", typeref::FRAGMENT_TYPE.cast::<PyObject>());
 
         opt!(mptr, c"OPT_APPEND_NEWLINE", opt::APPEND_NEWLINE);
+        opt!(mptr, c"OPT_ENSURE_ASCII", opt::ENSURE_ASCII);
         opt!(mptr, c"OPT_INDENT_2", opt::INDENT_2);
         opt!(mptr, c"OPT_NAIVE_UTC", opt::NAIVE_UTC);
         opt!(mptr, c"OPT_NON_STR_KEYS", opt::NON_STR_KEYS);

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,6 +14,7 @@ pub(crate) const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub(crate) const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub(crate) const APPEND_NEWLINE: Opt = 1 << 10;
 pub(crate) const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
+pub(crate) const ENSURE_ASCII: Opt = 1 << 12;
 
 // deprecated
 pub(crate) const SERIALIZE_DATACLASS: Opt = 0;
@@ -26,6 +27,7 @@ pub(crate) const NOT_PASSTHROUGH: Opt =
 
 #[allow(clippy::cast_possible_wrap)]
 pub(crate) const MAX_OPT: i32 = (APPEND_NEWLINE
+    | ENSURE_ASCII
     | INDENT_2
     | NAIVE_UTC
     | NON_STR_KEYS

--- a/src/serialize/serializer.rs
+++ b/src/serialize/serializer.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::opt::{Opt, APPEND_NEWLINE, INDENT_2};
+use crate::opt::{Opt, APPEND_NEWLINE, ENSURE_ASCII, INDENT_2};
 use crate::serialize::obtype::{pyobject_to_obtype, ObType};
 use crate::serialize::per_type::{
     BoolSerializer, DataclassGenericSerializer, Date, DateTime, DefaultSerializer,

--- a/src/serialize/writer/json.rs
+++ b/src/serialize/writer/json.rs
@@ -687,35 +687,52 @@ fn format_escaped_str_ascii<W>(writer: &mut W, value: &str)
 where
     W: ?Sized + io::Write + WriteExt,
 {
-    format_escaped_str(writer, value); // FIXME: Implement this still.
+    // Worst case: every char becomes \uXXXX plus quotes.
+    writer.reserve(value.len() * 6 + 2);
 
-    // writer.reserve(value.len() * 6 + 2); // worst case: every char becomes \uXXXX
+    unsafe {
+        writer.write_reserved_punctuation(b'"').unwrap();
 
-    // unsafe {
-    //     writer.write_reserved_punctuation(b'"').unwrap();
-    //     for c in value.chars() {
-    //         match c {
-    //             '"' => writer.write_reserved_str("\\\"").unwrap(),
-    //             '\\' => writer.write_reserved_str("\\\\").unwrap(),
-    //             '\u{08}' => writer.write_reserved_str("\\b").unwrap(),
-    //             '\u{0C}' => writer.write_reserved_str("\\f").unwrap(),
-    //             '\n' => writer.write_reserved_str("\\n").unwrap(),
-    //             '\r' => writer.write_reserved_str("\\r").unwrap(),
-    //             '\t' => writer.write_reserved_str("\\t").unwrap(),
-    //             c if c.is_ascii() => {
-    //                 let mut buf = [0u8; 4];
-    //                 let s = c.encode_utf8(&mut buf);
-    //                 writer.write_reserved_str(s).unwrap();
-    //             }
-    //             c => {
-    //                 let mut buf = [0u8; 6];
-    //                 let encoded = format!("\\u{:04X}", c as u32);
-    //                 writer.write_reserved_str(&encoded).unwrap();
-    //             }
-    //         }
-    //     }
-    //     writer.write_reserved_punctuation(b'"').unwrap();
-    // }
+        for c in value.chars() {
+            match c {
+                '"' => writer.write_reserved_fragment(b"\\\"").unwrap(),
+                '\\' => writer.write_reserved_fragment(b"\\\\").unwrap(),
+                '\u{08}' => writer.write_reserved_fragment(b"\\b").unwrap(),
+                '\u{0C}' => writer.write_reserved_fragment(b"\\f").unwrap(),
+                '\n' => writer.write_reserved_fragment(b"\\n").unwrap(),
+                '\r' => writer.write_reserved_fragment(b"\\r").unwrap(),
+                '\t' => writer.write_reserved_fragment(b"\\t").unwrap(),
+                c if c.is_ascii() => {
+                    // Write ASCII character directly.
+                    let mut buf = [0u8; 4];
+                    let s = c.encode_utf8(&mut buf);
+                    writer.write_reserved_fragment(s.as_bytes()).unwrap();
+                }
+                c => {
+                    // Write as \uXXXX.
+                    let code = c as u32;
+                    let buf = match code {
+                        0x0000..=0xFFFF => {
+                            // Basic Multilingual Plane
+                            let s = format!("\\u{:04x}", code);
+                            debug_assert_eq!(s.len(), 6);
+                            s
+                        }
+                        _ => {
+                            // Encode surrogate pairs.
+                            let code = code - 0x1_0000;
+                            let high = 0xD800 | ((code >> 10) & 0x3FF);
+                            let low = 0xDC00 | (code & 0x3FF);
+                            format!("\\u{:04x}\\u{:04x}", high, low)
+                        }
+                    };
+                    writer.write_reserved_fragment(buf.as_bytes()).unwrap();
+                }
+            }
+        }
+
+        writer.write_reserved_punctuation(b'"').unwrap();
+    }
 }
 
 #[inline]

--- a/src/serialize/writer/mod.rs
+++ b/src/serialize/writer/mod.rs
@@ -6,4 +6,6 @@ mod json;
 mod str;
 
 pub(crate) use byteswriter::{BytesWriter, WriteExt};
-pub(crate) use json::{set_str_formatter_fn, to_writer, to_writer_pretty};
+pub(crate) use json::{
+    set_str_formatter_fn, to_writer, to_writer_ascii, to_writer_pretty, to_writer_pretty_ascii,
+};

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -170,7 +170,7 @@ class TestApi:
         dumps() option out of range high
         """
         with pytest.raises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=1 << 12)
+            orjson.dumps(True, option=1 << 13)
 
     def test_opts_multiple(self):
         """

--- a/test/test_dumps_indent_ascii.py
+++ b/test/test_dumps_indent_ascii.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import json
+
 import pytest
 
 import orjson
@@ -36,12 +37,10 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
     def test_basic_equivalent(self, opt_indent_2, opt_ensure_ascii, opt_sort_keys):
         obj = {"a": "b", "c": {"d": True}, "e": [1, 2]}
@@ -58,12 +57,10 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_false", "sort_keys_true"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
     def test_basic_equivalent_with_emojis(
         self, opt_indent_2, opt_ensure_ascii, opt_sort_keys
@@ -82,12 +79,10 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
     def test_basic_equivalent_with_emojis_and_nonascii(
         self, opt_indent_2, opt_ensure_ascii, opt_sort_keys
@@ -106,14 +101,12 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
-    def test_empty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
+    def test_empty(self, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int):
         obj = [{}, [[[]]], {"key": []}]
 
         assert orjson.dumps(
@@ -128,14 +121,14 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
-    def test_twitter_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
+    def test_twitter_pretty(
+        self, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int
+    ):
         obj = read_fixture_obj("twitter.json.xz")
 
         assert orjson.dumps(
@@ -150,14 +143,14 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
-    def test_github_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
+    def test_github_pretty(
+        self, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int
+    ):
         obj = read_fixture_obj("github.json.xz")
 
         assert orjson.dumps(
@@ -172,14 +165,14 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
-    def test_canada_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
+    def test_canada_pretty(
+        self, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int
+    ):
         obj = read_fixture_obj("canada.json.xz")
 
         assert orjson.dumps(
@@ -194,14 +187,14 @@ class TestIndentedAsciiOutput:
     @pytest.mark.parametrize(
         "opt_ensure_ascii",
         [0, orjson.OPT_ENSURE_ASCII],
-        ids=["ensure_ascii_false", "ensure_ascii_true"],
+        ids=["no_ensure_ascii", "ensure_ascii"],
     )
     @pytest.mark.parametrize(
-        "opt_sort_keys",
-        [0, orjson.OPT_SORT_KEYS],
-        ids=["sort_keys_true", "sort_keys_false"],
+        "opt_sort_keys", [0, orjson.OPT_SORT_KEYS], ids=["no_sort_keys", "sort_keys"]
     )
-    def test_citm_catalog_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
+    def test_citm_catalog_pretty(
+        self, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int
+    ):
         obj = read_fixture_obj("citm_catalog.json.xz")
 
         assert orjson.dumps(

--- a/test/test_dumps_indent_ascii.py
+++ b/test/test_dumps_indent_ascii.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import datetime
 import json
 import pytest
 
@@ -9,7 +8,9 @@ import orjson
 from .util import needs_data, read_fixture_obj
 
 
-def _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2) -> bytes:
+def _json_dumps_encode_with_opts(
+    obj, opt_ensure_ascii: int, opt_indent_2: int, opt_sort_keys: int
+) -> bytes:
     """
     Helper function to mimic json.dumps with options.
     """
@@ -19,11 +20,16 @@ def _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2) -> bytes:
         ensure_ascii=bool(opt_ensure_ascii),
         # Minify separators if not indenting.
         separators=(",", ":") if not opt_indent_2 else None,
+        sort_keys=bool(opt_sort_keys),
     ).encode("utf-8")
 
 
 @needs_data
 class TestIndentedAsciiOutput:
+    """
+    Grid search test for orjson.dumps with different options, comparing against json.dumps.
+    """
+
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
     )
@@ -32,12 +38,19 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_basic_equivalent(self, opt_indent_2, opt_ensure_ascii):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_basic_equivalent(self, opt_indent_2, opt_ensure_ascii, opt_sort_keys):
         obj = {"a": "b", "c": {"d": True}, "e": [1, 2]}
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -47,12 +60,21 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_basic_equivalent_with_emojis(self, opt_indent_2, opt_ensure_ascii):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_false", "sort_keys_true"],
+    )
+    def test_basic_equivalent_with_emojis(
+        self, opt_indent_2, opt_ensure_ascii, opt_sort_keys
+    ):
         obj = {"a": "🩷b", "c🍉": {"d": True}, "e": [1, 2]}
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -62,12 +84,21 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_basic_equivalent_with_emojis_and_nonascii(self, opt_indent_2, opt_ensure_ascii):
-        obj = {"a": "🩷b", "c🍉": {"d": True}, "e_你好": [1, 2]}
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_basic_equivalent_with_emojis_and_nonascii(
+        self, opt_indent_2, opt_ensure_ascii, opt_sort_keys
+    ):
+        obj = {"z": "🩷b", "c🍉": {"d": True}, "e_你好": [1, 2]}
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -77,12 +108,19 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_empty(self, opt_ensure_ascii, opt_indent_2):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_empty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
         obj = [{}, [[[]]], {"key": []}]
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -92,12 +130,19 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_twitter_pretty(self, opt_ensure_ascii, opt_indent_2):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_twitter_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
         obj = read_fixture_obj("twitter.json.xz")
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -107,12 +152,19 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_github_pretty(self, opt_ensure_ascii, opt_indent_2):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_github_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
         obj = read_fixture_obj("github.json.xz")
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -122,12 +174,19 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_canada_pretty(self, opt_ensure_ascii, opt_indent_2):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_canada_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
         obj = read_fixture_obj("canada.json.xz")
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )
 
     @pytest.mark.parametrize(
         "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
@@ -137,9 +196,16 @@ class TestIndentedAsciiOutput:
         [0, orjson.OPT_ENSURE_ASCII],
         ids=["ensure_ascii_false", "ensure_ascii_true"],
     )
-    def test_citm_catalog_pretty(self, opt_ensure_ascii, opt_indent_2):
+    @pytest.mark.parametrize(
+        "opt_sort_keys",
+        [0, orjson.OPT_SORT_KEYS],
+        ids=["sort_keys_true", "sort_keys_false"],
+    )
+    def test_citm_catalog_pretty(self, opt_ensure_ascii, opt_indent_2, opt_sort_keys):
         obj = read_fixture_obj("citm_catalog.json.xz")
 
         assert orjson.dumps(
-            obj, option=opt_ensure_ascii | opt_indent_2
-        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+            obj, option=opt_ensure_ascii | opt_indent_2 | opt_sort_keys
+        ) == _json_dumps_encode_with_opts(
+            obj, opt_ensure_ascii, opt_indent_2, opt_sort_keys
+        )

--- a/test/test_dumps_indent_ascii.py
+++ b/test/test_dumps_indent_ascii.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import datetime
+import json
+import pytest
+
+import orjson
+
+from .util import needs_data, read_fixture_obj
+
+
+def _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2) -> bytes:
+    """
+    Helper function to mimic json.dumps with options.
+    """
+    return json.dumps(
+        obj,
+        indent=(2 if opt_indent_2 else None),
+        ensure_ascii=bool(opt_ensure_ascii),
+        # Minify separators if not indenting.
+        separators=(",", ":") if not opt_indent_2 else None,
+    ).encode("utf-8")
+
+
+@needs_data
+class TestIndentedAsciiOutput:
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_basic_equivalent(self, opt_indent_2, opt_ensure_ascii):
+        obj = {"a": "b", "c": {"d": True}, "e": [1, 2]}
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_basic_equivalent_with_emojis(self, opt_indent_2, opt_ensure_ascii):
+        obj = {"a": "🩷b", "c🍉": {"d": True}, "e": [1, 2]}
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_basic_equivalent_with_emojis_and_nonascii(self, opt_indent_2, opt_ensure_ascii):
+        obj = {"a": "🩷b", "c🍉": {"d": True}, "e_你好": [1, 2]}
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_empty(self, opt_ensure_ascii, opt_indent_2):
+        obj = [{}, [[[]]], {"key": []}]
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_twitter_pretty(self, opt_ensure_ascii, opt_indent_2):
+        obj = read_fixture_obj("twitter.json.xz")
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_github_pretty(self, opt_ensure_ascii, opt_indent_2):
+        obj = read_fixture_obj("github.json.xz")
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_canada_pretty(self, opt_ensure_ascii, opt_indent_2):
+        obj = read_fixture_obj("canada.json.xz")
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)
+
+    @pytest.mark.parametrize(
+        "opt_indent_2", [0, orjson.OPT_INDENT_2], ids=["no_indent", "indent_2"]
+    )
+    @pytest.mark.parametrize(
+        "opt_ensure_ascii",
+        [0, orjson.OPT_ENSURE_ASCII],
+        ids=["ensure_ascii_false", "ensure_ascii_true"],
+    )
+    def test_citm_catalog_pretty(self, opt_ensure_ascii, opt_indent_2):
+        obj = read_fixture_obj("citm_catalog.json.xz")
+
+        assert orjson.dumps(
+            obj, option=opt_ensure_ascii | opt_indent_2
+        ) == _json_dumps_encode_with_opts(obj, opt_ensure_ascii, opt_indent_2)

--- a/test/test_ensure_ascii.py
+++ b/test/test_ensure_ascii.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import datetime
+
+import orjson
+
+
+class TestEnsureAsciiOutput:
+    def test_all_ascii(self):
+        obj = {"a": "b", "c": {"d": True}, "e": [1, 2]}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII)
+            == b'{"a":"b","c":{"d":true},"e":[1,2]}'
+        )
+
+    def test_equivalent_emoji_key(self):
+        obj = {"🤨": "b", "c": {"d": True}, "e": [1, 2]}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII)
+            == b'{"\\ud83e\\udd28":"b","c":{"d":true},"e":[1,2]}'
+        )
+
+    def test_equivalent_emoji_value(self):
+        obj = {"a": "b", "🤨": {"d": True}, "e": [1, 2]}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII)
+            == b'{"a":"b","\\ud83e\\udd28":{"d":true},"e":[1,2]}'
+        )
+
+    def test_sort(self):
+        obj = {"b": 1, "a": 2, "c🤨": "d🔥"}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII | orjson.OPT_SORT_KEYS)
+            == b'{"a":2,"b":1,"c\\ud83e\\udd28":"d\\ud83d\\udd25"}'
+        )
+
+    def test_non_str(self):
+        obj = {1: 1, "a🔥": 2}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII | orjson.OPT_NON_STR_KEYS)
+            == b'{"1":1,"a\\ud83d\\udd25":2}'
+        )
+
+    def test_options(self):
+        obj = {
+            1: 1,
+            "b": True,
+            "a": datetime.datetime(1970, 1, 1),
+            "d🔥": "e🤨",
+        }
+        assert (
+            orjson.dumps(
+                obj,
+                option=orjson.OPT_ENSURE_ASCII
+                | orjson.OPT_SORT_KEYS
+                | orjson.OPT_NON_STR_KEYS
+                | orjson.OPT_NAIVE_UTC,
+            )
+            == b'{"1":1,"a":"1970-01-01T00:00:00+00:00","b":true,"d\\ud83d\\udd25":"e\\ud83e\\udd28"}'
+        )
+
+    def test_empty(self):
+        obj = [{}, [[[]]], {"key": []}]
+        ref = b'[{},[[[]]],{"key":[]}]'
+        assert orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII) == ref

--- a/test/test_ensure_ascii.py
+++ b/test/test_ensure_ascii.py
@@ -27,6 +27,30 @@ class TestEnsureAsciiOutput:
             == b'{"a":"b","\\ud83e\\udd28":{"d":true},"e":[1,2]}'
         )
 
+    def test_equivalent_non_emoji_value(self):
+        """
+        Test a lower code-point character that is not an emoji.
+
+        Characters with code points in range 0x0000 to 0xFFFF are handled
+        differently than characters beyond.
+        """
+        obj = {"ni_hao": "你_好"}
+        assert (
+            orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII)
+            == b'{"ni_hao":"\\u4f60_\\u597d"}'
+        )
+
+    def test_round_trip(self):
+        """
+        Test that the output can be loaded and dumped again.
+        """
+        obj = {"ni_hao": "你_好", "emoji": "🍉"}
+        dumped = orjson.dumps(obj, option=orjson.OPT_ENSURE_ASCII)
+        assert dumped == b'{"ni_hao":"\\u4f60_\\u597d","emoji":"\\ud83c\\udf49"}'
+        loaded = orjson.loads(dumped)
+        assert loaded == obj
+        assert orjson.dumps(loaded, option=orjson.OPT_ENSURE_ASCII) == dumped
+
     def test_sort(self):
         obj = {"b": 1, "a": 2, "c🤨": "d🔥"}
         assert (


### PR DESCRIPTION
### Changes
* Added `orjson.OPT_ENSURE_ASCII` functionality, which mirrors the `json.dumps(..., ensure_ascii=True)` implementation
* Added a complete grid search test which covers a variety of test objects with all combinations of `OPT_ENSURE_ASCII, OPT_INDENT_2, and OPT_SORT_KEYS` enabled, comparing back to `json.dumps(...)` versions of those (see `test/test_dumps_indent_ascii.py` file).
* Updated documentation in README to report new functionality. 

### Notes
* Note: Platform-specific optimized implementations of the new `format_escaped_str_ascii` function are not yet implemented. Currently, only a generic implementation is written. While optimizing this function is certainly possible, creating this MVP is what I set out to do first; I'd suggest that it is more than acceptable to merge in its current state.
* This is related to Issue #580. I was motivated by JSON-encoding values in such a way that they can be used as values in AWS S3 Metadata values (which only support ASCII characters). 

### Remaining Actions

* Update change log. I have not updated the change log yet.