### PR TITLE
Introduce `ffi::atomic::AtomicCULong` to produce correct `c_ulong` counterpart

### DIFF
--- a/src/ffi/atomic.rs
+++ b/src/ffi/atomic.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+//! Atomic types for platform-dependent c_ulong.
+//! See <https://github.com/PyO3/pyo3/blob/7836f150a0d0ba7d24264783ca6379dc1c61b8f4/pyo3-ffi/src/impl_/mod.rs#L1-L22>.
+
+#[cfg(Py_GIL_DISABLED)]
+mod atomic_c_ulong {
+    pub struct GetAtomicCULong<const WIDTH: usize>();
+
+    pub trait AtomicCULongType {
+        type Type;
+    }
+    impl AtomicCULongType for GetAtomicCULong<32> {
+        type Type = std::sync::atomic::AtomicU32;
+    }
+    impl AtomicCULongType for GetAtomicCULong<64> {
+        type Type = std::sync::atomic::AtomicU64;
+    }
+
+    pub type TYPE =
+        <GetAtomicCULong<{ std::mem::size_of::<std::os::raw::c_ulong>() * 8 }> as AtomicCULongType>::Type;
+}
+
+/// Typedef for an atomic integer to match the platform-dependent c_ulong type.
+#[cfg(Py_GIL_DISABLED)]
+#[doc(hidden)]
+pub type AtomicCULong = atomic_c_ulong::TYPE;

--- a/src/ffi/fragment.rs
+++ b/src/ffi/fragment.rs
@@ -3,7 +3,9 @@
 use core::ffi::c_char;
 
 #[cfg(Py_GIL_DISABLED)]
-use std::sync::atomic::{AtomicIsize, AtomicU32, AtomicU64};
+use crate::ffi::atomic::AtomicCULong;
+#[cfg(Py_GIL_DISABLED)]
+use std::sync::atomic::{AtomicIsize, AtomicU32};
 
 use core::ptr::null_mut;
 use pyo3_ffi::{
@@ -106,8 +108,8 @@ pub(crate) unsafe extern "C" fn orjson_fragment_dealloc(object: *mut PyObject) {
 }
 
 #[cfg(Py_GIL_DISABLED)]
-const FRAGMENT_TP_FLAGS: AtomicU64 =
-    AtomicU64::new(Py_TPFLAGS_DEFAULT | pyo3_ffi::Py_TPFLAGS_IMMUTABLETYPE);
+const FRAGMENT_TP_FLAGS: AtomicCULong =
+    AtomicCULong::new(Py_TPFLAGS_DEFAULT | pyo3_ffi::Py_TPFLAGS_IMMUTABLETYPE);
 
 #[cfg(all(Py_3_10, not(Py_GIL_DISABLED)))]
 const FRAGMENT_TP_FLAGS: core::ffi::c_ulong =

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+mod atomic;
 mod buffer;
 mod bytes;
 pub(crate) mod compat;


### PR DESCRIPTION
This PR takes [the approach adopted by pyo3_ffi](https://github.com/PyO3/pyo3/blob/7836f150a0d0ba7d24264783ca6379dc1c61b8f4/pyo3-ffi/src/impl_/mod.rs#L1-L22) to produce the correct `Atomic*` counterpart of `c_ulong` across different platforms.

[pyo3_ffi uses `MIT OR Apache-2.0`.](https://github.com/PyO3/pyo3/blob/7836f150a0d0ba7d24264783ca6379dc1c61b8f4/Cargo.toml#L12) Please inform me whether the current attribution conforms to the license of both projects. Thanks in advance.

Resolves #587.