### PR TITLE
feat: add option OPT_STRICT_FLOAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,21 +254,6 @@ b"[]"
 b"[]\n"
 ```
 
-##### OPT_APPEND_NEWLINE
-
-Casues the library to raise an error when attempting to serialize a invalid JSON value such as `NaN`, `Infinity`, or `-Infinity`.
-
-```python
->>> import orjson
->>> orjson.dumps({"invalid_float": float('nan')}, option=orjson.OPT_FAIL_ON_INVALID_FLOAT)
----------------------------------------------------------------------------
-TypeError                                 Traceback (most recent call last)
-Cell In[8], line 1
-----> 1 orjson.dumps({"invalid_float": float("nan")}, option=orjson.OPT_FAIL_ON_INVALID_FLOAT)
-
-TypeError: Invalid float
-```
-
 ##### OPT_INDENT_2
 
 Pretty-print output with an indent of two spaces. This is equivalent to
@@ -560,6 +545,21 @@ b'{"A":3,"a":1,"\xc3\xa4":2}'
 This is the same sorting behavior as the standard library.
 
 `dataclass` also serialize as maps but this has no effect on them.
+
+##### OPT_STRICT_FLOAT
+
+Casues the library to raise an error when attempting to serialize a invalid JSON value such as `NaN`, `Infinity`, or `-Infinity`.
+
+```python
+>>> import orjson
+>>> orjson.dumps({"invalid_float": float('nan')}, option=orjson.OPT_STRICT_FLOAT)
+---------------------------------------------------------------------------
+TypeError                                 Traceback (most recent call last)
+Cell In[8], line 1
+----> 1 orjson.dumps({"invalid_float": float("nan")}, option=orjson.OPT_STRICT_FLOAT)
+
+TypeError: Invalid float
+```
 
 ##### OPT_STRICT_INTEGER
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ b"[]"
 b"[]\n"
 ```
 
+##### OPT_APPEND_NEWLINE
+
+Casues the library to raise an error when attempting to serialize a invalid JSON value such as `NaN`, `Infinity`, or `-Infinity`.
+
+```python
+>>> import orjson
+>>> orjson.dumps({"invalid_float": float('nan')}, option=orjson.OPT_FAIL_ON_INVALID_FLOAT)
+---------------------------------------------------------------------------
+TypeError                                 Traceback (most recent call last)
+Cell In[8], line 1
+----> 1 orjson.dumps({"invalid_float": float("nan")}, option=orjson.OPT_FAIL_ON_INVALID_FLOAT)
+
+TypeError: Invalid float
+```
+
 ##### OPT_INDENT_2
 
 Pretty-print output with an indent of two spaces. This is equivalent to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ pub(crate) unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
         add!(mptr, c"Fragment", typeref::FRAGMENT_TYPE.cast::<PyObject>());
 
         opt!(mptr, c"OPT_APPEND_NEWLINE", opt::APPEND_NEWLINE);
+        opt!(mptr, c"OPT_FAIL_ON_INVALID_FLOAT", opt::FAIL_ON_INVALID_FLOAT);
         opt!(mptr, c"OPT_INDENT_2", opt::INDENT_2);
         opt!(mptr, c"OPT_NAIVE_UTC", opt::NAIVE_UTC);
         opt!(mptr, c"OPT_NON_STR_KEYS", opt::NON_STR_KEYS);
@@ -205,6 +206,7 @@ pub(crate) unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
         opt!(mptr, c"OPT_SORT_KEYS", opt::SORT_KEYS);
         opt!(mptr, c"OPT_STRICT_INTEGER", opt::STRICT_INTEGER);
         opt!(mptr, c"OPT_UTC_Z", opt::UTC_Z);
+        opt!(mptr, c"OPT_FAIL_ON_INVALID_FLOAT", opt::FAIL_ON_INVALID_FLOAT);
 
         add!(mptr, c"JSONDecodeError", typeref::JsonDecodeError);
         add!(mptr, c"JSONEncodeError", typeref::JsonEncodeError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,6 @@ pub(crate) unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
         add!(mptr, c"Fragment", typeref::FRAGMENT_TYPE.cast::<PyObject>());
 
         opt!(mptr, c"OPT_APPEND_NEWLINE", opt::APPEND_NEWLINE);
-        opt!(mptr, c"OPT_FAIL_ON_INVALID_FLOAT", opt::FAIL_ON_INVALID_FLOAT);
         opt!(mptr, c"OPT_INDENT_2", opt::INDENT_2);
         opt!(mptr, c"OPT_NAIVE_UTC", opt::NAIVE_UTC);
         opt!(mptr, c"OPT_NON_STR_KEYS", opt::NON_STR_KEYS);
@@ -204,9 +203,9 @@ pub(crate) unsafe extern "C" fn orjson_init_exec(mptr: *mut PyObject) -> c_int {
         opt!(mptr, c"OPT_SERIALIZE_NUMPY", opt::SERIALIZE_NUMPY);
         opt!(mptr, c"OPT_SERIALIZE_UUID", opt::SERIALIZE_UUID);
         opt!(mptr, c"OPT_SORT_KEYS", opt::SORT_KEYS);
+        opt!(mptr, c"OPT_STRICT_FLOAT", opt::STRICT_FLOAT);
         opt!(mptr, c"OPT_STRICT_INTEGER", opt::STRICT_INTEGER);
         opt!(mptr, c"OPT_UTC_Z", opt::UTC_Z);
-        opt!(mptr, c"OPT_FAIL_ON_INVALID_FLOAT", opt::FAIL_ON_INVALID_FLOAT);
 
         add!(mptr, c"JSONDecodeError", typeref::JsonDecodeError);
         add!(mptr, c"JSONEncodeError", typeref::JsonEncodeError);

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,7 +14,7 @@ pub(crate) const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub(crate) const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub(crate) const APPEND_NEWLINE: Opt = 1 << 10;
 pub(crate) const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
-pub(crate) const FAIL_ON_INVALID_FLOAT: Opt = 1 << 12;
+pub(crate) const STRICT_FLOAT: Opt = 1 << 12;
 
 // deprecated
 pub(crate) const SERIALIZE_DATACLASS: Opt = 0;
@@ -27,7 +27,6 @@ pub(crate) const NOT_PASSTHROUGH: Opt =
 
 #[allow(clippy::cast_possible_wrap)]
 pub(crate) const MAX_OPT: i32 = (APPEND_NEWLINE
-    | FAIL_ON_INVALID_FLOAT
     | INDENT_2
     | NAIVE_UTC
     | NON_STR_KEYS
@@ -39,5 +38,6 @@ pub(crate) const MAX_OPT: i32 = (APPEND_NEWLINE
     | SERIALIZE_NUMPY
     | SERIALIZE_UUID
     | SORT_KEYS
+    | STRICT_FLOAT
     | STRICT_INTEGER
     | UTC_Z) as i32;

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,6 +14,7 @@ pub(crate) const PASSTHROUGH_SUBCLASS: Opt = 1 << 8;
 pub(crate) const PASSTHROUGH_DATETIME: Opt = 1 << 9;
 pub(crate) const APPEND_NEWLINE: Opt = 1 << 10;
 pub(crate) const PASSTHROUGH_DATACLASS: Opt = 1 << 11;
+pub(crate) const FAIL_ON_INVALID_FLOAT: Opt = 1 << 12;
 
 // deprecated
 pub(crate) const SERIALIZE_DATACLASS: Opt = 0;
@@ -26,6 +27,7 @@ pub(crate) const NOT_PASSTHROUGH: Opt =
 
 #[allow(clippy::cast_possible_wrap)]
 pub(crate) const MAX_OPT: i32 = (APPEND_NEWLINE
+    | FAIL_ON_INVALID_FLOAT
     | INDENT_2
     | NAIVE_UTC
     | NON_STR_KEYS

--- a/src/serialize/error.rs
+++ b/src/serialize/error.rs
@@ -8,6 +8,7 @@ pub(crate) enum SerializeError {
     DefaultRecursionLimit,
     Integer53Bits,
     Integer64Bits,
+    InvalidFloat,
     InvalidStr,
     InvalidFragment,
     KeyMustBeStr,
@@ -36,6 +37,7 @@ impl core::fmt::Display for SerializeError {
             }
             SerializeError::Integer53Bits => write!(f, "Integer exceeds 53-bit range"),
             SerializeError::Integer64Bits => write!(f, "Integer exceeds 64-bit range"),
+            SerializeError::InvalidFloat => write!(f, "Invalid float"),
             SerializeError::InvalidStr => write!(f, "{}", crate::util::INVALID_STR),
             SerializeError::InvalidFragment => {
                 write!(f, "orjson.Fragment's content is not of type bytes or str")

--- a/src/serialize/per_type/dict.rs
+++ b/src/serialize/per_type/dict.rs
@@ -111,7 +111,7 @@ macro_rules! impl_serialize_entry {
             }
             ObType::Float => {
                 $map.serialize_key($key).unwrap();
-                $map.serialize_value(&FloatSerializer::new($value))?;
+                $map.serialize_value(&FloatSerializer::new($value, $self.state.opts()))?;
             }
             ObType::Bool => {
                 $map.serialize_key($key).unwrap();

--- a/src/serialize/per_type/float.rs
+++ b/src/serialize/per_type/float.rs
@@ -2,7 +2,7 @@
 
 use serde::ser::{Serialize, Serializer};
 
-use crate::{opt::{Opt, FAIL_ON_INVALID_FLOAT}, serialize::error::SerializeError};
+use crate::{opt::{Opt, STRICT_FLOAT}, serialize::error::SerializeError};
 
 pub(crate) struct FloatSerializer {
     ptr: *mut pyo3_ffi::PyObject,
@@ -26,7 +26,7 @@ impl Serialize for FloatSerializer {
     {
         let val = ffi!(PyFloat_AS_DOUBLE(self.ptr));
         
-        if unlikely!(opt_enabled!(self.opts, FAIL_ON_INVALID_FLOAT))
+        if unlikely!(opt_enabled!(self.opts, STRICT_FLOAT))
             && (val.is_nan() || val.is_infinite())
         {
             err!(SerializeError::InvalidFloat)

--- a/src/serialize/per_type/float.rs
+++ b/src/serialize/per_type/float.rs
@@ -26,10 +26,10 @@ impl Serialize for FloatSerializer {
     {
         let val = ffi!(PyFloat_AS_DOUBLE(self.ptr));
         
-        if opt_enabled!(self.opts, FAIL_ON_INVALID_FLOAT) {
-            if val.is_nan() || val.is_infinite() {
-                err!(SerializeError::InvalidFloat)
-            }
+        if unlikely!(opt_enabled!(self.opts, FAIL_ON_INVALID_FLOAT))
+            && (val.is_nan() || val.is_infinite())
+        {
+            err!(SerializeError::InvalidFloat)
         }
 
         serializer.serialize_f64(val)

--- a/src/serialize/per_type/list.rs
+++ b/src/serialize/per_type/list.rs
@@ -107,7 +107,7 @@ impl Serialize for ListTupleSerializer {
                     seq.serialize_element(&NoneSerializer::new()).unwrap();
                 }
                 ObType::Float => {
-                    seq.serialize_element(&FloatSerializer::new(value))?;
+                    seq.serialize_element(&FloatSerializer::new(value, self.state.opts()))?;
                 }
                 ObType::Bool => {
                     seq.serialize_element(&BoolSerializer::new(value)).unwrap();

--- a/src/serialize/serializer.rs
+++ b/src/serialize/serializer.rs
@@ -64,7 +64,7 @@ impl Serialize for PyObjectSerializer {
             ObType::StrSubclass => StrSubclassSerializer::new(self.ptr).serialize(serializer),
             ObType::Int => IntSerializer::new(self.ptr, self.state.opts()).serialize(serializer),
             ObType::None => NoneSerializer::new().serialize(serializer),
-            ObType::Float => FloatSerializer::new(self.ptr).serialize(serializer),
+            ObType::Float => FloatSerializer::new(self.ptr, self.state.opts()).serialize(serializer),
             ObType::Bool => BoolSerializer::new(self.ptr).serialize(serializer),
             ObType::Datetime => DateTime::new(self.ptr, self.state.opts()).serialize(serializer),
             ObType::Date => Date::new(self.ptr).serialize(serializer),

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -170,7 +170,7 @@ class TestApi:
         dumps() option out of range high
         """
         with pytest.raises(orjson.JSONEncodeError):
-            orjson.dumps(True, option=1 << 12)
+            orjson.dumps(True, option=1 << 13)
 
     def test_opts_multiple(self):
         """

--- a/test/test_float.py
+++ b/test/test_float.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import orjson
+import pytest
+import numpy as np
+
+class TestFloat:
+    @pytest.mark.parametrize("value", [
+        float('nan'),
+        float('infinity'),
+        float('-infinity'),
+        np.nan,
+        np.inf,
+        np.NINF
+    ])
+    def test_dumps_succeeds_on_invalid_float_without_option(self, value):
+        """
+        dumps() succeeds on invalid floats (NaN, Infinity, -Infinity),
+        without option OPT_FAIL_ON_INVALID_FLOAT
+        """
+        res = orjson.dumps(value)
+        assert res == b'null'
+
+    @pytest.mark.parametrize("value", [
+        float('nan'),
+        float('infinity'),
+        float('-infinity'),
+        np.nan,
+        np.inf,
+        np.NINF
+    ])
+    def test_dumps_fails_on_invalid_float_with_option(self, value):
+        """
+        dumps() fails with JSONEncodeError on invalid floats (NaN, Infinity, -Infinity),
+        with option OPT_FAIL_ON_INVALID_FLOAT
+        """
+        with pytest.raises(orjson.JSONEncodeError):
+            orjson.dumps(float('nan'), option=orjson.OPT_FAIL_ON_INVALID_FLOAT)

--- a/test/test_float.py
+++ b/test/test_float.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import orjson
-import pytest
 import numpy as np
+import pytest
+
+import orjson
+
 
 class TestFloat:
     @pytest.mark.parametrize("value", [

--- a/test/test_float.py
+++ b/test/test_float.py
@@ -16,7 +16,7 @@ class TestFloat:
     def test_dumps_succeeds_on_invalid_float_without_option(self, value):
         """
         dumps() succeeds on invalid floats (NaN, Infinity, -Infinity),
-        without option OPT_FAIL_ON_INVALID_FLOAT
+        without option OPT_STRICT_FLOAT
         """
         res = orjson.dumps(value)
         assert res == b'null'
@@ -32,7 +32,7 @@ class TestFloat:
     def test_dumps_fails_on_invalid_float_with_option(self, value):
         """
         dumps() fails with JSONEncodeError on invalid floats (NaN, Infinity, -Infinity),
-        with option OPT_FAIL_ON_INVALID_FLOAT
+        with option OPT_STRICT_FLOAT
         """
         with pytest.raises(orjson.JSONEncodeError):
-            orjson.dumps(float('nan'), option=orjson.OPT_FAIL_ON_INVALID_FLOAT)
+            orjson.dumps(float('nan'), option=orjson.OPT_STRICT_FLOAT)


### PR DESCRIPTION
Add option `OPT_STRICT_FLOAT` to fail when attempting to serialize invalid floating point numbers (`NaN`, `Infinity`, `-Infinity`), rather than converting to `null`.

This allows users to handle cases where the serialized JSON would be different when deserialzing.

## Bench mark tests

### After changes
| Dataset                          | Name                                 | Min                   | Max                  | Mean                | StdDev              | Median              | IQR                 | Outliers | OPS               | Rounds | Iterations |
|----------------------------------|--------------------------------------|-----------------------|----------------------|---------------------|---------------------|---------------------|---------------------|----------|-------------------|--------|------------|
| canada.json serialization        | test_dumps[canada.json-orjson]       | 3.2847 (1.0)          | 3.5891 (1.0)          | 3.4808 (1.0)         | 0.1193 (1.0)         | 3.4880 (1.0)         | 0.1383 (1.0)         | 1;0      | 287.2912 (1.0)    | 5      | 1000       |
| canada.json serialization        | test_dumps[canada.json-json]         | 53.6749 (16.34)       | 61.5021 (17.14)       | 57.5255 (16.53)      | 2.8387 (23.80)       | 57.0523 (16.36)      | 3.1694 (22.92)       | 2;0      | 17.3836 (0.06)    | 5      | 18         |
| citm_catalog.json serialization  | test_dumps[citm_catalog.json-orjson] | 457.1500 (1.0)        | 491.3666 (1.0)        | 471.9669 (1.0)       | 13.1761 (1.0)        | 468.3416 (1.0)       | 18.3300 (1.0)        | 2;0      | 2,118.7925 (1.0)  | 5      | 10000      |
| citm_catalog.json serialization  | test_dumps[citm_catalog.json-json]   | 3,766.4378 (8.24)     | 4,176.7522 (8.50)     | 3,955.6568 (8.38)    | 157.7054 (11.97)     | 3,923.7981 (8.38)    | 227.0969 (12.39)     | 2;0      | 252.8025 (0.12)   | 5      | 1000       |
| github.json serialization        | test_dumps[github.json-orjson]       | 20.5222 (1.0)         | 22.2400 (1.0)         | 21.3391 (1.0)        | 0.7803 (1.0)         | 21.5893 (1.0)        | 1.4006 (1.0)         | 3;0      | 46.8622 (1.0)     | 5      | 100000     |
| github.json serialization        | test_dumps[github.json-json]         | 177.3991 (8.64)       | 196.5864 (8.84)       | 189.8231 (8.90)      | 9.0014 (11.54)       | 196.0418 (9.08)      | 14.5856 (10.41)      | 1;0      | 5.2681 (0.11)     | 5      | 10000      |
| twitter.json serialization       | test_dumps[twitter.json-orjson]      | 233.2322 (1.0)        | 258.9844 (1.0)        | 246.1588 (1.0)       | 12.0674 (1.0)        | 248.5571 (1.0)       | 22.9553 (1.0)        | 3;0      | 4,062.4186 (1.0)  | 5      | 10000      |
| twitter.json serialization       | test_dumps[twitter.json-json]        | 1,705.8133 (7.31)     | 1,987.6210 (7.67)     | 1,799.5415 (7.31)    | 116.5602 (9.66)      | 1,770.0864 (7.12)    | 160.5328 (6.99)      | 1;0      | 555.6971 (0.14)   | 5      | 1000       |

 
### Benchmark against master branch

| Dataset                          | Name                                 | Min                   | Max                  | Mean                | StdDev              | Median              | IQR                 | Outliers | OPS               | Rounds | Iterations |
|----------------------------------|--------------------------------------|-----------------------|----------------------|---------------------|---------------------|---------------------|---------------------|----------|-------------------|--------|------------|
| canada.json serialization        | test_dumps[canada.json-orjson]       | 3.1220 (1.0)          | 3.4250 (1.0)          | 3.2669 (1.0)         | 0.1189 (1.0)         | 3.2970 (1.0)         | 0.1748 (1.0)         | 2;0      | 306.1040 (1.0)    | 5      | 1000       |
| canada.json serialization        | test_dumps[canada.json-json]         | 54.1017 (17.33)       | 65.4944 (19.12)       | 58.8816 (18.02)      | 4.7291 (39.76)       | 59.7720 (18.13)      | 7.3956 (42.30)       | 2;0      | 16.9832 (0.06)    | 5      | 19         |
| citm_catalog.json serialization  | test_dumps[citm_catalog.json-orjson] | 454.2471 (1.0)        | 488.6039 (1.0)        | 470.0407 (1.0)       | 15.6919 (1.0)        | 469.5506 (1.0)       | 29.4838 (1.0)        | 2;0      | 2,127.4755 (1.0)  | 5      | 10000      |
| citm_catalog.json serialization  | test_dumps[citm_catalog.json-json]   | 3,785.1678 (8.33)     | 4,179.1181 (8.55)     | 3,958.8131 (8.42)    | 177.2010 (11.29)     | 3,882.1394 (8.27)    | 312.1638 (10.59)     | 1;0      | 252.6010 (0.12)   | 5      | 1000       |
| github.json serialization        | test_dumps[github.json-orjson]       | 21.9955 (1.0)         | 25.1784 (1.0)         | 23.6283 (1.0)        | 1.3207 (1.0)         | 23.2247 (1.0)        | 2.1487 (1.0)         | 2;0      | 42.3221 (1.0)     | 5      | 100000     |
| github.json serialization        | test_dumps[github.json-json]         | 181.5460 (8.25)       | 210.0416 (8.34)       | 192.5024 (8.15)      | 11.2146 (8.49)       | 190.3760 (8.20)      | 15.4046 (7.17)       | 1;0      | 5.1947 (0.12)     | 5      | 10000      |
| twitter.json serialization       | test_dumps[twitter.json-orjson]      | 246.3341 (1.0)        | 268.1238 (1.0)        | 254.7371 (1.0)       | 9.1197 (1.0)         | 253.3927 (1.0)       | 14.5981 (1.0)        | 1;0      | 3,925.6163 (1.0)  | 5      | 10000      |
| twitter.json serialization       | test_dumps[twitter.json-json]        | 1,692.2346 (6.87)     | 1,963.0872 (7.32)     | 1,823.2605 (7.16)    | 100.6003 (11.03)     | 1,822.0593 (7.19)    | 132.5100 (9.08)      | 2;0      | 548.4680 (0.14)   | 5      | 1000       |

