### PR TITLE
Use license-expression in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "orjson"
 version = "3.11.2"
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/ijl/orjson"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,12 @@
 [project]
 name = "orjson"
 version = "3.11.2"
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/ijl/orjson"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
`maturin` does support PEP 639 license expression. Replace the license classifier with `project.license`.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

_Also removed the unused `project.repository` key. The url is already present in `project.urls.source`._

Metadata diff
```diff
 ...
-Classifier: License :: OSI Approved :: Apache Software License
-Classifier: License :: OSI Approved :: MIT License
 ...
 License-File: LICENSE-APACHE
 License-File: LICENSE-MIT
+License-Expression: Apache-2.0 OR MIT
 Requires-Python: >=3.9
 Project-URL: source, https://github.com/ijl/orjson
 ...
```