### PR TITLE
Gate avx512 under x86_64 target

### DIFF
--- a/src/str/mod.rs
+++ b/src/str/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#[cfg(feature = "avx512")]
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 mod avx512;
 mod pystr;
 mod pyunicode_new;

--- a/src/str/pystr.rs
+++ b/src/str/pystr.rs
@@ -21,15 +21,15 @@ fn to_str_via_ffi(op: *mut PyObject) -> Option<&'static str> {
     }
 }
 
-#[cfg(feature = "avx512")]
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 pub type StrDeserializer = unsafe fn(&str) -> *mut PyObject;
 
-#[cfg(feature = "avx512")]
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 static mut STR_CREATE_FN: StrDeserializer = super::scalar::str_impl_kind_scalar;
 
 pub fn set_str_create_fn() {
     unsafe {
-        #[cfg(feature = "avx512")]
+        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
         if std::is_x86_feature_detected!("avx512vl") {
             STR_CREATE_FN = crate::str::avx512::create_str_impl_avx512vl;
         }
@@ -82,9 +82,9 @@ impl PyStr {
                 ptr: nonnull!(use_immortal!(EMPTY_UNICODE)),
             };
         }
-        #[cfg(not(feature = "avx512"))]
+        #[cfg(not(all(target_arch = "x86_64", feature = "avx512")))]
         let str_ptr = unsafe { super::scalar::str_impl_kind_scalar(buf) };
-        #[cfg(feature = "avx512")]
+        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
         let str_ptr = unsafe { STR_CREATE_FN(buf) };
         debug_assert!(!str_ptr.is_null());
         PyStr {


### PR DESCRIPTION
Make avx512 check consistent with other places, e.g. https://github.com/ijl/orjson/blob/a4fdeb3aff125d501ec0dd0577f9b38b2b977b4f/src/serialize/writer/json.rs#L570
This fixes the cross compilation to riscv64:
```
maturinBuildHook flags: --jobs=16 --offline --target riscv64gc-unknown-linux-gnu --manylinux off --strip --release --out /build/source/dist --interpreter python3.13
📦 Including license file `LICENSE-APACHE`
📦 Including license file `LICENSE-MIT`
🍹 Building a mixed python/rust project
🔗 Found pyo3-ffi bindings
🐍 Found CPython 3.13
   Compiling target-lexicon v0.13.2
   Compiling once_cell v1.21.3
   Compiling shlex v1.3.0
   Compiling libc v0.2.175
   Compiling serde v1.0.219
   Compiling cfg-if v1.0.1
   Compiling serde_json v1.0.142
   Compiling version_check v0.9.5
   Compiling itoa v1.0.15
   Compiling ryu v1.0.20
   Compiling memchr v2.7.5
   Compiling associative-cache v2.0.0
   Compiling smallvec v1.15.1
   Compiling xxhash-rust v0.8.15
   Compiling jiff v0.2.15
   Compiling uuid v1.18.0
   Compiling cc v1.2.32
   Compiling encoding_rs v0.8.35
   Compiling half v2.6.0
   Compiling itoap v1.0.1
   Compiling bytes v1.10.1
   Compiling bytecount v0.6.9
   Compiling simdutf8 v0.1.5
   Compiling pyo3-build-config v0.25.1
   Compiling pyo3-ffi v0.25.1
   Compiling orjson v3.11.3 (/build/source)
error: This macro cannot be used on the current target.
                                   You can prevent it from being used in other architectures by
                                   guarding it behind a cfg(any(target_arch = "x86", target_arch = "x86_64")).
  --> src/str/pystr.rs:32:12
   |
32 |         if std::is_x86_feature_detected!("avx512vl") {
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `std::is_x86_feature_detected` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0432]: unresolved import `core::arch::x86_64`
 --> src/str/avx512.rs:5:17
  |
5 | use core::arch::x86_64::{
  |                 ^^^^^^ could not find `x86_64` in `arch`

error: the feature named `avx512f` is not valid for this target
  --> src/str/avx512.rs:11:18
   |
11 | #[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi2")]
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `avx512f` is not valid for this target

error: the feature named `avx512bw` is not valid for this target
  --> src/str/avx512.rs:11:18
   |
11 | #[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi2")]
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `avx512bw` is not valid for this target

error: the feature named `avx512vl` is not valid for this target
  --> src/str/avx512.rs:11:18
   |
11 | #[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi2")]
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `avx512vl` is not valid for this target

error: the feature named `bmi2` is not valid for this target
  --> src/str/avx512.rs:11:18
   |
11 | #[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi2")]
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bmi2` is not valid for this target

For more information about this error, try `rustc --explain E0432`.
error: could not compile `orjson` (lib) due to 6 previous errors
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_BUILD_EXTENSION_MODULE="1" PYO3_CONFIG_FILE="/build/source/target/maturin/pyo3-config-riscv64gc-unknown-linux-gnu-3.13.txt" "cargo" "rus
tc" "--jobs" "16" "--target" "riscv64gc-unknown-linux-gnu" "--message-format" "json-render-diagnostics" "--offline" "--manifest-path" "/build/source/Cargo.toml" "--release" "--lib" "--" "-C" "strip=symbols"`
```