### PR TITLE
Enable prebuilt wheel publishing for Python 3.14t (free-threaded)

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          { interpreter: 'python3.14t', compatibility: "manylinux_2_34", publish: false },
+          { interpreter: 'python3.14t', compatibility: "manylinux_2_34", publish: true },
           { interpreter: 'python3.14', compatibility: "manylinux_2_17", publish: true },
           { interpreter: 'python3.13', compatibility: "manylinux_2_17", publish: true },
           { interpreter: 'python3.12', compatibility: "manylinux_2_17", publish: true },
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          { interpreter: 'python3.14t', compatibility: "manylinux_2_34", publish: false },
+          { interpreter: 'python3.14t', compatibility: "manylinux_2_34", publish: true },
           { interpreter: 'python3.14', compatibility: "manylinux_2_17", publish: true },
           { interpreter: 'python3.13', compatibility: "manylinux_2_17", publish: true },
           { interpreter: 'python3.12', compatibility: "manylinux_2_17", publish: true },
@@ -454,7 +454,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          { version: '3.14t', macosx_target: "15.0", publish: false },
+          { version: '3.14t', macosx_target: "15.0", publish: true },
           { version: '3.14', macosx_target: "15.0", publish: true },
           { version: '3.13', macosx_target: "15.0", publish: true },
           { version: '3.12', macosx_target: "15.0", publish: true },


### PR DESCRIPTION
### Summary
This PR enables publishing of prebuilt wheels for Python 3.14t (the new free-threaded interpreter) on macOS ARM64 and manylinux (amd64 + aarch64).

### Details
- Python 3.14t builds were already defined in the CI matrix but had `publish: false`.
- Verified locally on macOS M1 that:
  - The wheel builds successfully with `maturin 1.9.6`
  - The resulting artifact is tagged `cp314t` and imports correctly under the free-threaded interpreter.
- Updated CI entries:
  - `macos_aarch64`: `publish: true` for 3.14t
  - `manylinux_amd64`: `publish: true` for python3.14t
  - `manylinux_aarch64`: `publish: true` for python3.14t

### Rationale
These prebuilt wheels will save time for users of the free-threaded Python runtime (no need to build from source), and CI already validates the builds with `UNSAFE_PYO3_BUILD_FREE_THREADED=1`.

### Notes
- musllinux wheels remain untouched — skipped for now since official 3.14t musllinux images are still stabilizing.
- Verified that test suites (`pytest -v test`) pass locally for the free-threaded interpreter.

Thanks for the fantastic project — this adds convenience for everyone moving to Python 3.14 free-threaded.
