### PR TITLE
fix(build): Check target arch instead of host when enabling avx512 feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,9 +45,16 @@ fn main() {
         }
     }
 
-    #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
-    if version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
-        println!("cargo:rustc-cfg=feature=\"avx512\"");
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH is not set.");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS")
+        .expect("CARGO_CFG_TARGET_OS is not set.");
+
+    // Only enable the avx512 feature if the TARGET is x86_64 (and not macOS).
+    if target_arch == "x86_64" && target_os != "macos" {
+        if version_check::is_min_version("1.89.0").unwrap_or(false) && is_64_bit_python {
+            println!("cargo:rustc-cfg=feature=\"avx512\"");
+        }
     }
 
     if version_check::supports_feature("cold_path").unwrap_or(false) {


### PR DESCRIPTION
This PR fixes a cross-compilation issue where the `avx512` feature was being enabled based on the host architecture (`x86_64`) instead of the target architecture.

As discussed in issue #603, the stabilization of AVX-512 in Rust 1.89 exposed a latent bug in the `build.rs` script. The script uses a compile-time `#[cfg(target_arch = "x86_64")]` to decide whether to enable the `avx512` feature. When cross-compiling on an x86-64 host for a non-x86 target (e.g., `aarch64-linux-android`), this condition is incorrectly met.

This leads to a compilation failure, as x86-specific intrinsics and macros like `is_x86_feature_detected!` are not valid for an `aarch64` target.

This fix replaces the compile-time host check with a runtime check inside the `build.rs` script. It now inspects the `CARGO_CFG_TARGET_ARCH` and `CARGO_CFG_TARGET_OS` environment variables, which are set by `cargo` to reflect the final target.

With this change, the `avx512` feature is now only enabled if the **target** architecture is `x86_64` (and the OS is not `macos`), resolving the cross-compilation failure and making the build logic robust.