### PR TITLE
Add missing build.rs script to cargo include

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
 keywords = ["fast", "json", "dataclass", "dataclasses", "datetime", "rfc", "8259", "3339"]
 include = [
+    "build.rs",
     "Cargo.toml",
     "CHANGELOG.md",
     "include/yyjson",


### PR DESCRIPTION
I think with the default setup this doesn't cause any issues but our monorepo has an obscure setup and this being missing messes up the output of cargo metadata (doesn't realize there is a build.rs) and so it would be greatly appreciated to include it here.