### PR TITLE
Refactor serialization to handle recursion limits and state management

### DIFF
--- a/src/serialize/per_type/dict.rs
+++ b/src/serialize/per_type/dict.rs
@@ -426,10 +426,13 @@ pub(crate) struct DictNonStrKey {
 impl DictNonStrKey {
     fn pyobject_to_string(
         key: *mut crate::ffi::PyObject,
-        opts: crate::opt::Opt,
+        state: SerializerState,
     ) -> Result<String, SerializeError> {
+        if state.recursion_limit() {
+            return Err(SerializeError::RecursionLimit);
+        }
         unsafe {
-            match pyobject_to_obtype(key, opts) {
+            match pyobject_to_obtype(key, state.opts()) {
                 ObType::None => Ok(String::from("null")),
                 ObType::Bool => {
                     if unsafe { core::ptr::eq(key, TRUE) } {
@@ -440,14 +443,14 @@ impl DictNonStrKey {
                 }
                 ObType::Int => non_str_int(key),
                 ObType::Float => non_str_float(key),
-                ObType::Datetime => non_str_datetime(key, opts),
+                ObType::Datetime => non_str_datetime(key, state.opts()),
                 ObType::Date => non_str_date(key),
-                ObType::Time => non_str_time(key, opts),
+                ObType::Time => non_str_time(key, state.opts()),
                 ObType::Uuid => non_str_uuid(key),
                 ObType::Enum => {
                     let value = ffi!(PyObject_GetAttr(key, VALUE_STR));
                     debug_assert!(ffi!(Py_REFCNT(value)) >= 2);
-                    let ret = Self::pyobject_to_string(value, opts);
+                    let ret = Self::pyobject_to_string(value, state.copy_for_recursive_call());
                     ffi!(Py_DECREF(value));
                     ret
                 }
@@ -480,7 +483,9 @@ impl Serialize for DictNonStrKey {
 
         pydict_next!(self.ptr, &mut pos, &mut next_key, &mut next_value);
 
-        let opts = self.state.opts() & NOT_PASSTHROUGH;
+        let opts = (self.state.opts() & 0xFFFF) & NOT_PASSTHROUGH;
+        let mut state = SerializerState::new(opts);
+        state = state.copy_from(self.state);
 
         let len = isize_to_usize(ffi!(Py_SIZE(self.ptr)));
         assume!(len > 0);
@@ -501,10 +506,10 @@ impl Serialize for DictNonStrKey {
                     }
                     None => err!(SerializeError::InvalidStr),
                 },
-                Err(_) => match Self::pyobject_to_string(key, opts) {
+                Err(_) => match Self::pyobject_to_string(key, state) {
                     Ok(key_as_str) => items.push((key_as_str, value)),
                     Err(err) => err!(err),
-                },
+                }
             }
         }
 

--- a/src/serialize/per_type/pyenum.rs
+++ b/src/serialize/per_type/pyenum.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright ijl (2018-2025)
 
+use crate::serialize::error::SerializeError;
 use crate::serialize::serializer::PyObjectSerializer;
 use crate::typeref::VALUE_STR;
 use serde::ser::{Serialize, Serializer};
@@ -22,10 +23,18 @@ impl Serialize for EnumSerializer<'_> {
     where
         S: Serializer,
     {
+        if self.previous.state.recursion_limit() {
+            cold_path!();
+            err!(SerializeError::RecursionLimit)
+        }
         let value = ffi!(PyObject_GetAttr(self.previous.ptr, VALUE_STR));
         debug_assert!(ffi!(Py_REFCNT(value)) >= 2);
-        let ret = PyObjectSerializer::new(value, self.previous.state, self.previous.default)
-            .serialize(serializer);
+        let ret = PyObjectSerializer::new(
+            value,
+            self.previous.state.copy_for_recursive_call(),
+            self.previous.default,
+        )
+        .serialize(serializer);
         ffi!(Py_DECREF(value));
         ret
     }


### PR DESCRIPTION
Fix for CVE: https://avd.aquasec.com/nvd/cve-2025-67221

- This pull request introduces improved recursion and default call tracking in the serializer state, enforces recursion limits to prevent stack overflows, and refactors how state is copied and passed in recursive serialization calls. 
- These changes enhance the safety and correctness of serializing complex or deeply nested Python objects.
