### PR TITLE
formatter: reserve_minimum in end_ methods

### DIFF
--- a/src/serialize/writer/formatter.rs
+++ b/src/serialize/writer/formatter.rs
@@ -131,7 +131,7 @@ pub(crate) trait Formatter {
     where
         W: ?Sized + WriteExt + bytes::BufMut,
     {
-        debug_assert_has_capacity!(writer);
+        reserve_minimum!(writer);
         unsafe {
             writer.put_u8(b']');
         }
@@ -175,7 +175,7 @@ pub(crate) trait Formatter {
     where
         W: ?Sized + WriteExt + bytes::BufMut,
     {
-        debug_assert_has_capacity!(writer);
+        reserve_minimum!(writer);
         unsafe {
             writer.put_u8(b'}');
         }


### PR DESCRIPTION
In highly nested json objects it's possible to have a lot of consecutive closing characters that are added by end_array and end_object. These methods adds one byte without checking the buffer capacity, so it's possible to try to write when there's no capacity.

This patch makes sure that the buffer has at least minimum space before writing.

This is the upstream commit that removes this check: c369ea44820e2e0798f17f99a0dff65bec2186a9
```
$ git log -p c369ea44820e2e0798f17f99a0dff65bec2186a9 -- src/serialize/writer/formatter.rs
```

Fix https://github.com/ijl/orjson/issues/636